### PR TITLE
Add Whisper Transcriber skeleton with tests

### DIFF
--- a/src/clip_exporter.py
+++ b/src/clip_exporter.py
@@ -1,0 +1,6 @@
+from pathlib import Path
+
+
+def export_clip(input_file: Path, start: float, end: float, output_file: Path):
+    # Stub that just copies the input file
+    output_file.write_bytes(input_file.read_bytes())

--- a/src/diarizer.py
+++ b/src/diarizer.py
@@ -1,0 +1,4 @@
+class Diarizer:
+    def tag_speakers(self, transcript: str) -> str:
+        # Stub that just returns the transcript unchanged
+        return transcript

--- a/src/keyword_index.py
+++ b/src/keyword_index.py
@@ -1,0 +1,28 @@
+import json
+from pathlib import Path
+from typing import List
+
+
+class KeywordIndex:
+    def __init__(self, path: Path):
+        self.path = path
+        self.keywords: List[str] = []
+        self.load()
+
+    def load(self):
+        if self.path.exists():
+            self.keywords = json.loads(self.path.read_text())
+
+    def save(self):
+        self.path.write_text(json.dumps(self.keywords))
+
+    def add(self, word: str):
+        if word not in self.keywords:
+            self.keywords.append(word)
+            self.save()
+
+    def search(self, transcript: str) -> List[str]:
+        return [kw for kw in self.keywords if kw.lower() in transcript.lower()]
+
+    def find_editorials(self, transcript: str) -> List[str]:
+        return [line for line in transcript.splitlines() if 'EDITORIAL' in line.upper()]

--- a/src/main.py
+++ b/src/main.py
@@ -1,0 +1,41 @@
+import argparse
+from pathlib import Path
+
+from transcribe_worker import TranscribeWorker
+from diarizer import Diarizer
+from transcript_aggregator import TranscriptAggregator
+from keyword_index import KeywordIndex
+from settings import Settings
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Whisper Transcriber (stub)")
+    parser.add_argument('files', nargs='+', help='Audio files to transcribe')
+    parser.add_argument('--keyword', help='Keyword to search after transcription')
+    args = parser.parse_args()
+
+    settings = Settings()
+    settings.load()
+    kw_index = KeywordIndex(settings.keyword_path)
+
+    worker = TranscribeWorker()
+    diarizer = Diarizer()
+    agg = TranscriptAggregator()
+
+    for f in args.files:
+        text = worker.transcribe(f)
+        text = diarizer.tag_speakers(text)
+        agg.add(f, text)
+        print(f"Processed {f}")
+
+    transcript = agg.merged_text()
+    print("\nFull Transcript:\n", transcript)
+
+    if args.keyword:
+        kw_index.add(args.keyword)
+        matches = kw_index.search(transcript)
+        print(f"\nKeyword matches: {matches}")
+
+
+if __name__ == '__main__':
+    main()

--- a/src/settings.py
+++ b/src/settings.py
@@ -1,0 +1,22 @@
+import json
+import os
+from pathlib import Path
+from dataclasses import dataclass, field
+
+
+APP_DIR = Path(os.getenv('APPDATA') or Path.home() / '.whisper_transcriber')
+SETTINGS_FILE = APP_DIR / 'settings.json'
+
+
+@dataclass
+class Settings:
+    keyword_path: Path = field(default=APP_DIR / 'keywords.json')
+
+    def load(self):
+        if SETTINGS_FILE.exists():
+            data = json.loads(SETTINGS_FILE.read_text())
+            self.keyword_path = Path(data.get('keyword_path', self.keyword_path))
+
+    def save(self):
+        APP_DIR.mkdir(parents=True, exist_ok=True)
+        SETTINGS_FILE.write_text(json.dumps({'keyword_path': str(self.keyword_path)}))

--- a/src/transcribe_worker.py
+++ b/src/transcribe_worker.py
@@ -1,0 +1,4 @@
+class TranscribeWorker:
+    def transcribe(self, file_path: str) -> str:
+        # Stub transcription
+        return f"[00:00] Speaker 1: Transcribed text from {file_path}"

--- a/src/transcript_aggregator.py
+++ b/src/transcript_aggregator.py
@@ -1,0 +1,12 @@
+from typing import List, Dict
+
+
+class TranscriptAggregator:
+    def __init__(self):
+        self.transcripts: List[Dict] = []
+
+    def add(self, file_path: str, transcript: str):
+        self.transcripts.append({'file': file_path, 'text': transcript})
+
+    def merged_text(self) -> str:
+        return '\n'.join(t['text'] for t in self.transcripts)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,3 @@
+import sys
+from pathlib import Path
+sys.path.append(str(Path(__file__).resolve().parents[1] / 'src'))

--- a/tests/test_keyword_index.py
+++ b/tests/test_keyword_index.py
@@ -1,0 +1,10 @@
+from keyword_index import KeywordIndex
+from pathlib import Path
+
+
+def test_keyword_add_and_search(tmp_path):
+    path = tmp_path / 'keywords.json'
+    kw = KeywordIndex(path)
+    kw.add('test')
+    result = kw.search('this is a test transcript')
+    assert 'test' in result

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,0 +1,11 @@
+from settings import Settings
+
+
+def test_settings_load_save(tmp_path, monkeypatch):
+    monkeypatch.setenv('APPDATA', str(tmp_path))
+    s = Settings()
+    s.keyword_path = tmp_path / 'kw.json'
+    s.save()
+    s.keyword_path = None
+    s.load()
+    assert s.keyword_path == tmp_path / 'kw.json'

--- a/tests/test_transcribe_worker.py
+++ b/tests/test_transcribe_worker.py
@@ -1,0 +1,7 @@
+from transcribe_worker import TranscribeWorker
+
+
+def test_transcribe_stub():
+    worker = TranscribeWorker()
+    result = worker.transcribe('audio.wav')
+    assert 'audio.wav' in result

--- a/tests/test_transcript_aggregator.py
+++ b/tests/test_transcript_aggregator.py
@@ -1,0 +1,8 @@
+from transcript_aggregator import TranscriptAggregator
+
+
+def test_merge():
+    agg = TranscriptAggregator()
+    agg.add('a.wav', 'hello')
+    agg.add('b.wav', 'world')
+    assert agg.merged_text() == 'hello\nworld'


### PR DESCRIPTION
## Summary
- implement a minimal skeleton of the Whisper Transcriber
- add stub modules for transcription, diarization, keyword indexing, etc.
- include simple pytest tests
- remove compiled artifacts

## Testing
- `pytest -q`