### PR TITLE
Implement Whisper transcribe worker

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+openai-whisper

--- a/src/transcribe_worker.py
+++ b/src/transcribe_worker.py
@@ -1,0 +1,21 @@
+import whisper
+
+class TranscribeWorker:
+    """Loads a Whisper model and transcribes audio files."""
+
+    def __init__(self, model_name: str = "base"):
+        self.model_name = model_name
+        self.model = whisper.load_model(model_name)
+
+    def transcribe(self, audio_path: str):
+        """Transcribe the given audio file and return segments."""
+        result = self.model.transcribe(audio_path)
+        segments = []
+        for seg in result.get("segments", []):
+            segments.append({
+                "start": float(seg.get("start", 0.0)),
+                "end": float(seg.get("end", 0.0)),
+                "speaker": "Speaker 1",
+                "text": seg.get("text", "").strip(),
+            })
+        return segments

--- a/tests/test_transcribe_worker.py
+++ b/tests/test_transcribe_worker.py
@@ -1,0 +1,32 @@
+import os
+import sys
+import types
+import importlib
+from unittest.mock import MagicMock
+
+# Add src directory to path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+def test_transcribe_worker_returns_structured_segments(monkeypatch):
+    fake_model = MagicMock()
+    fake_model.transcribe.return_value = {
+        "segments": [
+            {"start": 0.0, "end": 1.0, "text": "Hello"},
+            {"start": 1.0, "end": 2.0, "text": "World"},
+        ]
+    }
+    fake_whisper = types.ModuleType('whisper')
+    fake_whisper.load_model = MagicMock(return_value=fake_model)
+    monkeypatch.setitem(sys.modules, 'whisper', fake_whisper)
+
+    transcribe_worker = importlib.import_module('transcribe_worker')
+    worker = transcribe_worker.TranscribeWorker()
+    segments = worker.transcribe('dummy.wav')
+
+    expected = [
+        {"start": 0.0, "end": 1.0, "speaker": "Speaker 1", "text": "Hello"},
+        {"start": 1.0, "end": 2.0, "speaker": "Speaker 1", "text": "World"},
+    ]
+    assert segments == expected
+    fake_whisper.load_model.assert_called_once_with('base')
+    fake_model.transcribe.assert_called_once_with('dummy.wav')


### PR DESCRIPTION
## Summary
- add openai-whisper to dependencies
- implement `TranscribeWorker` that loads Whisper and transcribes audio
- add unit test mocking the Whisper API

## Testing
- `pytest -q`