### PR TITLE
Add transcript aggregator

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@
 ### Locating Transcription and Diarization
 
 Timestamped transcription segments are generated in `src/transcribe_worker.py` using the Whisper library. Speaker labeling is performed in `src/diarizer.py` with `pyannote.audio`. See the unit tests in `tests/` for basic usage.
+The `TranscriptAggregator` in `src/transcript_aggregator.py` can merge these segment lists into a single timeline.
 
 ## 4 — If an AI Agent Will Write the Code
 

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,5 @@
+"""PodcastAssistant public interface."""
+
+from .transcript_aggregator import TranscriptAggregator
+
+__all__ = ["TranscriptAggregator"]

--- a/src/transcript_aggregator.py
+++ b/src/transcript_aggregator.py
@@ -1,0 +1,21 @@
+from typing import List, Dict
+
+class TranscriptAggregator:
+    """Collects transcript segments from multiple audio files."""
+
+    def __init__(self):
+        self._segments: List[Dict] = []
+
+    def add_segments(self, audio_file: str, segments: List[Dict]):
+        """Add segments for the given audio file.
+
+        Each segment will be copied and annotated with the source filename.
+        """
+        for seg in segments:
+            entry = seg.copy()
+            entry["file"] = audio_file
+            self._segments.append(entry)
+
+    def get_transcript(self) -> List[Dict]:
+        """Return all collected segments ordered by start time."""
+        return sorted(self._segments, key=lambda s: s.get("start", 0.0))

--- a/tests/test_transcript_aggregator.py
+++ b/tests/test_transcript_aggregator.py
@@ -1,0 +1,32 @@
+import os
+import sys
+import importlib
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+
+def test_transcript_aggregator_merges_and_sorts():
+    agg_module = importlib.import_module('transcript_aggregator')
+    agg_module = importlib.reload(agg_module)
+    aggregator = agg_module.TranscriptAggregator()
+
+    segments_a = [
+        {'start': 2.0, 'end': 2.5, 'speaker': 'A', 'text': 'Bye'},
+        {'start': 0.0, 'end': 1.0, 'speaker': 'A', 'text': 'Hi'},
+    ]
+    segments_b = [
+        {'start': 1.5, 'end': 2.0, 'speaker': 'B', 'text': 'Mid'},
+    ]
+
+    aggregator.add_segments('a.wav', segments_a)
+    aggregator.add_segments('b.wav', segments_b)
+
+    transcript = aggregator.get_transcript()
+
+    expected = [
+        {'start': 0.0, 'end': 1.0, 'speaker': 'A', 'text': 'Hi', 'file': 'a.wav'},
+        {'start': 1.5, 'end': 2.0, 'speaker': 'B', 'text': 'Mid', 'file': 'b.wav'},
+        {'start': 2.0, 'end': 2.5, 'speaker': 'A', 'text': 'Bye', 'file': 'a.wav'},
+    ]
+
+    assert transcript == expected


### PR DESCRIPTION
## Summary
- implement `TranscriptAggregator` for merging transcript segments
- expose `TranscriptAggregator` from package root
- document aggregator usage in the README
- test merging and sorting behaviour

## Testing
- `pytest -q`