### PR TITLE
Implement keyword index module with tests

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,5 +1,6 @@
 """PodcastAssistant public interface."""
 
 from .transcript_aggregator import TranscriptAggregator
+from .keyword_index import KeywordIndex
 
-__all__ = ["TranscriptAggregator"]
+__all__ = ["TranscriptAggregator", "KeywordIndex"]

--- a/src/keyword_index.py
+++ b/src/keyword_index.py
@@ -1,0 +1,51 @@
+import json
+from typing import List, Dict
+
+
+class KeywordIndex:
+    """Manage persistent keyword lists and provide search utilities."""
+
+    def __init__(self, path: str):
+        self.path = path
+        self.keywords: List[str] = []
+        self.load()
+
+    def load(self) -> None:
+        """Load keywords from disk if the file exists."""
+        try:
+            with open(self.path, "r", encoding="utf-8") as fh:
+                self.keywords = json.load(fh)
+        except FileNotFoundError:
+            self.keywords = []
+
+    def save(self) -> None:
+        """Persist the current keywords to disk."""
+        with open(self.path, "w", encoding="utf-8") as fh:
+            json.dump(self.keywords, fh, indent=2)
+
+    def add_keyword(self, keyword: str) -> None:
+        """Add a keyword to the list and save if not already present."""
+        if keyword not in self.keywords:
+            self.keywords.append(keyword)
+            self.save()
+
+    def remove_keyword(self, keyword: str) -> None:
+        """Remove a keyword from the list and save."""
+        if keyword in self.keywords:
+            self.keywords.remove(keyword)
+            self.save()
+
+    def search(self, segments: List[Dict], query: str) -> List[Dict]:
+        """Return transcript segments containing the given text query."""
+        query_lc = query.lower()
+        return [seg for seg in segments if query_lc in seg.get("text", "").lower()]
+
+    def find_all_editorial(self, segments: List[Dict]) -> List[Dict]:
+        """Return segments that contain any stored keyword."""
+        keywords_lc = [k.lower() for k in self.keywords]
+        results = []
+        for seg in segments:
+            text_lc = seg.get("text", "").lower()
+            if any(k in text_lc for k in keywords_lc):
+                results.append(seg)
+        return results

--- a/tests/test_keyword_index.py
+++ b/tests/test_keyword_index.py
@@ -1,0 +1,60 @@
+import os
+import sys
+import json
+import importlib
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+
+def test_keyword_index_persistence(tmp_path):
+    path = tmp_path / 'keywords.json'
+    ki_module = importlib.import_module('keyword_index')
+    ki_module = importlib.reload(ki_module)
+    index = ki_module.KeywordIndex(str(path))
+
+    assert index.keywords == []
+
+    index.add_keyword('ad')
+    index.add_keyword('sponsor')
+
+    with open(path, 'r', encoding='utf-8') as fh:
+        data = json.load(fh)
+    assert data == ['ad', 'sponsor']
+
+    index2 = ki_module.KeywordIndex(str(path))
+    assert index2.keywords == ['ad', 'sponsor']
+
+
+def test_keyword_index_search(tmp_path):
+    path = tmp_path / 'keywords.json'
+    ki_module = importlib.import_module('keyword_index')
+    ki_module = importlib.reload(ki_module)
+    index = ki_module.KeywordIndex(str(path))
+
+    segments = [
+        {'text': 'Hello World'},
+        {'text': 'Other text'},
+        {'text': 'WORLD domination'},
+    ]
+
+    results = index.search(segments, 'world')
+    assert results == [segments[0], segments[2]]
+
+
+def test_keyword_index_find_all_editorial(tmp_path):
+    path = tmp_path / 'keywords.json'
+    ki_module = importlib.import_module('keyword_index')
+    ki_module = importlib.reload(ki_module)
+    index = ki_module.KeywordIndex(str(path))
+
+    index.add_keyword('ad')
+    index.add_keyword('sponsor')
+
+    segments = [
+        {'text': 'This is an ad spot'},
+        {'text': 'Just regular discussion'},
+        {'text': 'Our Sponsor thanks you'},
+    ]
+
+    results = index.find_all_editorial(segments)
+    assert results == [segments[0], segments[2]]


### PR DESCRIPTION
## Summary
- add new `KeywordIndex` module for storing keywords and searching transcripts
- expose `KeywordIndex` from `src.__init__`
- test keyword persistence, searching and editorial lookup

## Testing
- `pytest -q`