### PR TITLE
Add ClipExporter with ffmpeg-python

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@
 | `ClipExporter`        | Cuts audio for highlighted range via FFmpeg            |
 | `Settings`            | Persists UI prefs & keyword path                       |
 | `Installer`           | NSIS script for final .exe                             |
+The `ClipExporter` in `src/clip_exporter.py` wraps ffmpeg-python and provides
+`export_clip(audio_path, start, end, dest_path)` for saving short audio clips.
 
 ### Locating Transcription and Diarization
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 openai-whisper
 pyannote.audio
+ffmpeg-python

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -2,5 +2,6 @@
 
 from .transcript_aggregator import TranscriptAggregator
 from .keyword_index import KeywordIndex
+from .clip_exporter import ClipExporter
 
-__all__ = ["TranscriptAggregator", "KeywordIndex"]
+__all__ = ["TranscriptAggregator", "KeywordIndex", "ClipExporter"]

--- a/src/clip_exporter.py
+++ b/src/clip_exporter.py
@@ -1,0 +1,12 @@
+import ffmpeg
+
+class ClipExporter:
+    """Export a clipped portion of an audio file using ffmpeg-python."""
+
+    def export_clip(self, audio_path: str, start: float, end: float, dest_path: str) -> str:
+        """Clip audio between ``start`` and ``end`` seconds and save to ``dest_path``."""
+        stream = ffmpeg.input(audio_path, ss=start, to=end)
+        stream = stream.output(dest_path)
+        stream = stream.overwrite_output()
+        stream.run()
+        return dest_path

--- a/tests/test_clip_exporter.py
+++ b/tests/test_clip_exporter.py
@@ -1,0 +1,32 @@
+import os
+import sys
+import types
+import importlib
+from unittest.mock import MagicMock
+
+# add src directory to path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+
+def test_export_clip_invokes_ffmpeg(monkeypatch):
+    fake_stream = MagicMock()
+    fake_output_stream = MagicMock()
+    fake_output_stream.overwrite_output.return_value = fake_output_stream
+    fake_output_stream.run.return_value = None
+    fake_stream.output.return_value = fake_output_stream
+
+    fake_ffmpeg = types.ModuleType('ffmpeg')
+    fake_ffmpeg.input = MagicMock(return_value=fake_stream)
+    monkeypatch.setitem(sys.modules, 'ffmpeg', fake_ffmpeg)
+
+    clip_mod = importlib.import_module('clip_exporter')
+    clip_mod = importlib.reload(clip_mod)
+    exporter = clip_mod.ClipExporter()
+
+    result = exporter.export_clip('in.wav', 0.5, 2.5, 'out.wav')
+
+    fake_ffmpeg.input.assert_called_once_with('in.wav', ss=0.5, to=2.5)
+    fake_stream.output.assert_called_once_with('out.wav')
+    fake_output_stream.overwrite_output.assert_called_once()
+    fake_output_stream.run.assert_called_once()
+    assert result == 'out.wav'


### PR DESCRIPTION
## Summary
- implement `ClipExporter` for clipping audio segments
- expose `ClipExporter` in package interface
- document `ClipExporter` usage in README
- add ffmpeg-python dependency
- test ffmpeg invocation through new exporter

## Testing
- `pytest -q`