### PR TITLE
Add PySide6 GUI skeleton

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 openai-whisper
 pyannote.audio
 ffmpeg-python
+PySide6

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -4,5 +4,12 @@ from .transcript_aggregator import TranscriptAggregator
 from .keyword_index import KeywordIndex
 from .clip_exporter import ClipExporter
 from .settings import Settings
+from .main_window import MainWindow
 
-__all__ = ["TranscriptAggregator", "KeywordIndex", "ClipExporter", "Settings"]
+__all__ = [
+    "TranscriptAggregator",
+    "KeywordIndex",
+    "ClipExporter",
+    "Settings",
+    "MainWindow",
+]

--- a/src/main_window.py
+++ b/src/main_window.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+"""PySide6 GUI for the Podcast Assistant."""
+
+from PySide6 import QtWidgets, QtCore
+
+from transcribe_worker import TranscribeWorker
+from diarizer import Diarizer
+
+
+class TranscriberThread(QtCore.QThread):
+    """Thread wrapper around :class:`TranscribeWorker`."""
+
+    progress = QtCore.Signal(float)
+    finished = QtCore.Signal(list)
+
+    def __init__(self, audio_path: str, model: str = "base", parent=None) -> None:
+        super().__init__(parent)
+        self.audio_path = audio_path
+        self.worker = TranscribeWorker(model)
+
+    def run(self) -> None:  # pragma: no cover - not exercised in tests
+        segments = self.worker.transcribe(self.audio_path)
+        self.progress.emit(1.0)
+        self.finished.emit(segments)
+
+
+class DiarizerThread(QtCore.QThread):
+    """Thread wrapper around :class:`Diarizer`."""
+
+    progress = QtCore.Signal(float)
+    finished = QtCore.Signal(list)
+
+    def __init__(self, audio_path: str, segments: list, parent=None) -> None:
+        super().__init__(parent)
+        self.audio_path = audio_path
+        self.segments = segments
+        self.worker = Diarizer()
+
+    def run(self) -> None:  # pragma: no cover - not exercised in tests
+        labeled = self.worker.assign_speakers(self.audio_path, self.segments)
+        self.progress.emit(1.0)
+        self.finished.emit(labeled)
+
+
+class MainWindow(QtWidgets.QMainWindow):
+    """Main application window with drag-drop file list and transcript viewer."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.setWindowTitle("Whisper Transcriber")
+        central = QtWidgets.QWidget()
+        self.setCentralWidget(central)
+        layout = QtWidgets.QVBoxLayout(central)
+
+        self.file_list = QtWidgets.QListWidget()
+        self.file_list.setAcceptDrops(True)
+        layout.addWidget(self.file_list)
+
+        self.transcript = QtWidgets.QPlainTextEdit()
+        layout.addWidget(self.transcript)
+
+    # Drag and drop events
+    def dragEnterEvent(self, event):  # pragma: no cover - relies on GUI runtime
+        if event.mimeData().hasUrls():
+            event.acceptProposedAction()
+
+    def dropEvent(self, event):  # pragma: no cover - relies on GUI runtime
+        for url in event.mimeData().urls():
+            self.add_file(url.toLocalFile())
+
+    def add_file(self, path: str) -> None:
+        """Add an audio file entry with a progress bar."""
+        item = QtWidgets.QListWidgetItem(path)
+        widget = QtWidgets.QWidget()
+        h = QtWidgets.QHBoxLayout(widget)
+        h.setContentsMargins(0, 0, 0, 0)
+        label = QtWidgets.QLabel(path)
+        progress = QtWidgets.QProgressBar()
+        progress.setRange(0, 100)
+        h.addWidget(label)
+        h.addWidget(progress)
+        self.file_list.addItem(item)
+        self.file_list.setItemWidget(item, widget)
+
+    # Placeholder hooks for workers
+    def start_transcription(self, path: str) -> None:
+        """Start transcribing a file."""
+        thread = TranscriberThread(path, parent=self)
+        thread.finished.connect(lambda segs: self.display_segments(segs))
+        thread.start()
+
+    def display_segments(self, segments: list) -> None:
+        """Append segments to the transcript display."""
+        for seg in segments:
+            text = f"[{seg.get('speaker', '')}] {seg.get('text', '')}\n"
+            self.transcript.appendPlainText(text)

--- a/tests/test_main_window.py
+++ b/tests/test_main_window.py
@@ -1,0 +1,71 @@
+import os
+import sys
+import types
+import importlib
+
+# add src directory to path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+
+def make_pyside6_stub():
+    class StubObject:
+        def __init__(self, *a, **kw):
+            pass
+
+        def __getattr__(self, name):
+            def method(*a, **kw):
+                return None
+            return method
+
+    class Signal:
+        def __init__(self, *a):
+            pass
+
+        def connect(self, slot):
+            pass
+
+        def emit(self, *args):
+            pass
+
+    qtwidgets = types.ModuleType('PySide6.QtWidgets')
+    for cls in [
+        'QWidget',
+        'QMainWindow',
+        'QVBoxLayout',
+        'QListWidget',
+        'QPlainTextEdit',
+        'QProgressBar',
+        'QListWidgetItem',
+        'QHBoxLayout',
+        'QLabel',
+    ]:
+        qtwidgets.__dict__[cls] = type(cls, (StubObject,), {})
+
+    qtcore = types.ModuleType('PySide6.QtCore')
+    qtcore.QThread = type('QThread', (StubObject,), {'start': lambda self: None})
+    qtcore.QObject = StubObject
+    qtcore.Signal = Signal
+
+    pyside6 = types.ModuleType('PySide6')
+    pyside6.QtWidgets = qtwidgets
+    pyside6.QtCore = qtcore
+    return {'PySide6': pyside6, 'PySide6.QtWidgets': qtwidgets, 'PySide6.QtCore': qtcore}
+
+
+def test_main_window_instantiates(monkeypatch):
+    stubs = make_pyside6_stub()
+    for name, module in stubs.items():
+        monkeypatch.setitem(sys.modules, name, module)
+
+    tw = types.ModuleType('transcribe_worker')
+    tw.TranscribeWorker = lambda *a, **k: None
+    dr = types.ModuleType('diarizer')
+    dr.Diarizer = lambda *a, **k: None
+    monkeypatch.setitem(sys.modules, 'transcribe_worker', tw)
+    monkeypatch.setitem(sys.modules, 'diarizer', dr)
+
+    mw_module = importlib.import_module('main_window')
+    mw_module = importlib.reload(mw_module)
+
+    window = mw_module.MainWindow()
+    assert window is not None


### PR DESCRIPTION
## Summary
- list PySide6 dependency
- implement a minimal PySide6 MainWindow
- expose `MainWindow` in the package
- provide tests that stub PySide6 to ensure the GUI can instantiate

## Testing
- `pytest -q`