### PR TITLE
Add transcript exporter module

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@
 | `TranscriptAggregator`| Merges worker output into ordered transcript           |
 | `KeywordIndex`        | Loads/saves keyword list, search, “find all editorial” |
 | `ClipExporter`        | Cuts audio for highlighted range via FFmpeg            |
+| `TranscriptExporter`  | Exports transcript segments to TXT, JSON, and SRT |
 | `Settings`            | Persists UI prefs & keyword path                       |
 | `Installer`           | NSIS script for final .exe                             |
 The `ClipExporter` in `src/clip_exporter.py` wraps ffmpeg-python and provides

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -3,6 +3,7 @@
 from .transcript_aggregator import TranscriptAggregator
 from .keyword_index import KeywordIndex
 from .clip_exporter import ClipExporter
+from .transcript_exporter import export_txt, export_json, export_srt
 from .settings import Settings
 from .main_window import MainWindow
 
@@ -10,6 +11,9 @@ __all__ = [
     "TranscriptAggregator",
     "KeywordIndex",
     "ClipExporter",
+    "export_txt",
+    "export_json",
+    "export_srt",
     "Settings",
     "MainWindow",
 ]

--- a/src/transcript_exporter.py
+++ b/src/transcript_exporter.py
@@ -1,0 +1,39 @@
+"""Utilities to export transcript segments to various text formats."""
+
+from __future__ import annotations
+
+import json
+from typing import List, Dict
+
+
+def export_txt(segments: List[Dict]) -> str:
+    """Return the transcript as plain text with each segment on a new line."""
+    lines = [seg.get("text", "") for seg in segments]
+    return "\n".join(lines)
+
+
+def export_json(segments: List[Dict]) -> str:
+    """Return the transcript segments serialized as formatted JSON."""
+    return json.dumps(segments, indent=2, ensure_ascii=False)
+
+
+def _format_timestamp(seconds: float) -> str:
+    hours = int(seconds // 3600)
+    minutes = int((seconds % 3600) // 60)
+    secs = int(seconds % 60)
+    millis = int(round((seconds - int(seconds)) * 1000))
+    return f"{hours:02d}:{minutes:02d}:{secs:02d},{millis:03d}"
+
+
+def export_srt(segments: List[Dict]) -> str:
+    """Return the transcript in SubRip (SRT) subtitle format."""
+    lines: List[str] = []
+    for idx, seg in enumerate(segments, 1):
+        start = _format_timestamp(float(seg.get("start", 0.0)))
+        end = _format_timestamp(float(seg.get("end", 0.0)))
+        text = seg.get("text", "")
+        lines.append(str(idx))
+        lines.append(f"{start} --> {end}")
+        lines.append(text)
+        lines.append("")  # blank line after each entry
+    return "\n".join(lines).rstrip()  # remove trailing newline

--- a/tests/test_transcript_exporter.py
+++ b/tests/test_transcript_exporter.py
@@ -1,0 +1,28 @@
+import os
+import sys
+import json
+import importlib
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+
+def test_exporter_outputs_formats():
+    mod = importlib.import_module('transcript_exporter')
+    mod = importlib.reload(mod)
+    segments = [
+        {'start': 0.0, 'end': 1.0, 'speaker': 'A', 'text': 'Hello'},
+        {'start': 1.0, 'end': 2.5, 'speaker': 'B', 'text': 'World'},
+    ]
+
+    assert mod.export_txt(segments) == 'Hello\nWorld'
+    assert mod.export_json(segments) == json.dumps(segments, indent=2, ensure_ascii=False)
+
+    expected_srt = (
+        '1\n'
+        '00:00:00,000 --> 00:00:01,000\n'
+        'Hello\n\n'
+        '2\n'
+        '00:00:01,000 --> 00:00:02,500\n'
+        'World'
+    )
+    assert mod.export_srt(segments) == expected_srt


### PR DESCRIPTION
## Summary
- implement `transcript_exporter` with export functions for TXT, JSON and SRT
- expose export helpers in `src/__init__.py`
- test the exporter outputs
- document the new module in the README

## Testing
- `pytest -q`