### PR TITLE
Improve timestamp formatting

### DIFF
--- a/src/transcript_exporter.py
+++ b/src/transcript_exporter.py
@@ -18,10 +18,11 @@ def export_json(segments: List[Dict]) -> str:
 
 
 def _format_timestamp(seconds: float) -> str:
-    hours = int(seconds // 3600)
-    minutes = int((seconds % 3600) // 60)
-    secs = int(seconds % 60)
-    millis = int(round((seconds - int(seconds)) * 1000))
+    """Return a timestamp in ``HH:MM:SS,mmm`` format."""
+    millis_total = int(round(seconds * 1000))
+    seconds_total, millis = divmod(millis_total, 1000)
+    minutes_total, secs = divmod(seconds_total, 60)
+    hours, minutes = divmod(minutes_total, 60)
     return f"{hours:02d}:{minutes:02d}:{secs:02d},{millis:03d}"
 
 

--- a/tests/test_transcript_exporter.py
+++ b/tests/test_transcript_exporter.py
@@ -26,3 +26,10 @@ def test_exporter_outputs_formats():
         'World'
     )
     assert mod.export_srt(segments) == expected_srt
+
+
+def test_format_timestamp_rounding():
+    mod = importlib.import_module('transcript_exporter')
+    mod = importlib.reload(mod)
+
+    assert mod._format_timestamp(0.9995) == '00:00:01,000'


### PR DESCRIPTION
## Summary
- ensure timestamps never exceed `999` milliseconds in `transcript_exporter`
- verify rounding behavior for `_format_timestamp`

## Testing
- `pytest -q`