### PR TITLE
Add file operations to NSIS installer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [Unreleased]
+### Added
+- Initial changelog with sections for future releases.
+- NSIS script now copies `dist/WhisperTranscriber.exe` into the install
+  directory and cleans it up during uninstall.
+

--- a/installer/whisper_transcriber.nsi
+++ b/installer/whisper_transcriber.nsi
@@ -8,7 +8,14 @@ OutFile "WhisperTranscriberSetup.exe"
 InstallDir "$PROGRAMFILES\WhisperTranscriber"
 
 Section "MainSection" SEC01
-    ; TODO: add files
+    SetOutPath "$INSTDIR"
+    File "..\dist\WhisperTranscriber.exe"
+SectionEnd
+
+Section "Uninstall"
+    Delete "$INSTDIR\WhisperTranscriber.exe"
+    Delete "$INSTDIR\Uninstall.exe"
+    RMDir "$INSTDIR"
 SectionEnd
 
 Section -Post


### PR DESCRIPTION
## Summary
- create a changelog to track notable updates
- copy the built executable into `$INSTDIR` in the NSIS script
- clean up installed files when uninstalling

## Testing
- `pytest -q`
- `makensis installer/whisper_transcriber.nsi` *(fails: command not found)*