### PR TITLE
Add dependency bootstrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,4 +7,6 @@ All notable changes to this project will be documented in this file.
 - Initial changelog with sections for future releases.
 - NSIS script now copies `dist/WhisperTranscriber.exe` into the install directory and cleans it up during uninstall.
 - Project plan updated to cover automatic dependency bootstrapping with progress dialog.
+- Runtime bootstrapper installs dependencies listed in `requirements.txt` at
+  startup with a progress dialog before launching the main window.
 

--- a/src/bootstrapper.py
+++ b/src/bootstrapper.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+"""Install required packages at runtime if missing."""
+
+import os
+import sys
+import subprocess
+import importlib.util
+from PySide6 import QtCore
+
+
+class Bootstrapper(QtCore.QThread):
+    """Check and install dependencies listed in requirements.txt."""
+
+    progress = QtCore.Signal(float)
+    finished = QtCore.Signal()
+
+    def __init__(self, requirements_path: str | None = None, parent=None) -> None:
+        super().__init__(parent)
+        if requirements_path is None:
+            requirements_path = os.path.join(os.path.dirname(__file__), '..', 'requirements.txt')
+        self.requirements_path = os.path.abspath(requirements_path)
+
+    def _read_packages(self) -> list[str]:
+        with open(self.requirements_path, 'r', encoding='utf-8') as fh:
+            return [line.strip() for line in fh if line.strip() and not line.startswith('#')]
+
+    def _missing_packages(self, packages: list[str]) -> list[str]:
+        missing = []
+        for pkg in packages:
+            name = pkg.split('==')[0]
+            if importlib.util.find_spec(name) is None:
+                missing.append(pkg)
+        return missing
+
+    def run(self) -> None:  # pragma: no cover - integration with PySide6 runtime
+        pkgs = self._read_packages()
+        missing = self._missing_packages(pkgs)
+        total = len(missing)
+        for i, pkg in enumerate(missing):
+            subprocess.run([sys.executable, '-m', 'pip', 'install', pkg], check=False)
+            if total:
+                self.progress.emit((i + 1) / total)
+        self.finished.emit()

--- a/src/run_app.py
+++ b/src/run_app.py
@@ -1,9 +1,25 @@
 from PySide6 import QtWidgets
 from main_window import MainWindow
+from bootstrapper import Bootstrapper
 
 
 def main() -> None:
     app = QtWidgets.QApplication([])
+
+    bootstrapper = Bootstrapper()
+    progress = QtWidgets.QProgressDialog(
+        "Installing dependencies...", None, 0, 100
+    )
+    progress.setWindowTitle("Bootstrapping")
+    progress.setAutoClose(False)
+    progress.setAutoReset(False)
+
+    bootstrapper.progress.connect(lambda p: progress.setValue(int(p * 100)))
+    bootstrapper.finished.connect(progress.accept)
+
+    bootstrapper.start()
+    progress.exec()
+
     window = MainWindow()
     window.show()
     app.exec()

--- a/tests/test_bootstrapper.py
+++ b/tests/test_bootstrapper.py
@@ -1,0 +1,86 @@
+import os
+import sys
+import types
+import importlib
+
+# add src directory to path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+
+def make_pyside6_stub():
+    class StubObject:
+        def __init__(self, *a, **kw):
+            pass
+
+        def __getattr__(self, name):
+            def method(*a, **kw):
+                return None
+            return method
+
+    class Signal:
+        def __init__(self, *a):
+            self._slots = []
+
+        def connect(self, slot):
+            self._slots.append(slot)
+
+        def emit(self, *args):
+            for s in list(self._slots):
+                s(*args)
+
+    class QThread(StubObject):
+        def start(self):
+            if hasattr(self, "run"):
+                self.run()
+
+    qtcore = types.ModuleType('PySide6.QtCore')
+    qtcore.QThread = QThread
+    qtcore.QObject = StubObject
+    qtcore.Signal = Signal
+
+    pyside6 = types.ModuleType('PySide6')
+    pyside6.QtCore = qtcore
+
+    return {'PySide6': pyside6, 'PySide6.QtCore': qtcore}
+
+
+def test_bootstrapper_installs_missing(monkeypatch, tmp_path):
+    stubs = make_pyside6_stub()
+    for name, module in stubs.items():
+        monkeypatch.setitem(sys.modules, name, module)
+
+    missing = {'pkgA': True, 'pkgB': False, 'pkgC': True}
+
+    def fake_find_spec(name):
+        if missing.get(name):
+            return None
+        return object()
+
+    runs = []
+
+    def fake_run(args, check=False):
+        runs.append(args)
+
+    monkeypatch.setattr(importlib.util, 'find_spec', fake_find_spec)
+    import subprocess
+    monkeypatch.setattr(subprocess, 'run', fake_run)
+
+    req_path = tmp_path / 'reqs.txt'
+    req_path.write_text('pkgA\npkgB\npkgC\n')
+
+    bs_module = importlib.import_module('bootstrapper')
+    bs_module = importlib.reload(bs_module)
+    boot = bs_module.Bootstrapper(str(req_path))
+
+    progress = []
+    boot.progress.connect(lambda p: progress.append(p))
+    boot.finished.connect(lambda: progress.append('done'))
+
+    boot.run()
+
+    expected_runs = [
+        [sys.executable, '-m', 'pip', 'install', 'pkgA'],
+        [sys.executable, '-m', 'pip', 'install', 'pkgC'],
+    ]
+    assert runs == expected_runs
+    assert progress == [0.5, 1.0, 'done']


### PR DESCRIPTION
## Summary
- add a `Bootstrapper` thread that installs missing packages and emits progress
- hook bootstrapper into `run_app` so dependencies install before the main window loads
- test bootstrapper behaviour with monkeypatched `find_spec` and `subprocess.run`
- document new feature in changelog

## Testing
- `pytest -q`