### PR TITLE
Install PySide6 before launching GUI bootstrap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,3 +11,7 @@ All notable changes to this project will be documented in this file.
   startup with a progress dialog before launching the main window.
 - Uninstaller removes packages installed by the bootstrapper during uninstall.
 
+### Changed
+- Bootstrapper now installs PySide6 first so the progress window can launch
+  before installing remaining dependencies.
+

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 ## 1 — Core Functionality
 
-- On startup, check for required dependencies. If any are missing, open a
-  bootstrap window that installs them with a progress bar, then closes to launch
-  the main application.
+- On startup, the bootstrapper first ensures PySide6 is installed so the Qt
+  progress window can launch. The window then installs any remaining
+  dependencies with a progress bar before starting the main application.
 - Accept multiple audio files (browse or drag-drop) and let the user re-order them.
 - Perform local Whisper sentence-level transcription with timestamps and Speaker 1/2/3 tags (users can rename later).
 - Display live transcript plus a per-file progress bar during processing.
@@ -38,7 +38,7 @@
 | `ClipExporter`        | Cuts audio for highlighted range via FFmpeg            |
 | `TranscriptExporter`  | Exports transcript segments to TXT, JSON, and SRT |
 | `Settings`            | Persists UI prefs & keyword path                       |
-| `Bootstrapper`        | Checks dependencies and installs missing packages with a progress dialog |
+| `Bootstrapper`        | Installs PySide6 if needed and then shows a progress dialog while installing the rest |
 | `Installer`           | NSIS script for final .exe                             |
 | `uninstaller.py`      | Removes packages during uninstall |
 The `ClipExporter` in `src/clip_exporter.py` wraps ffmpeg-python and provides

--- a/src/bootstrapper.py
+++ b/src/bootstrapper.py
@@ -6,6 +6,18 @@ import os
 import sys
 import subprocess
 import importlib.util
+
+
+def ensure_pyside6() -> None:
+    """Install PySide6 if it's not already available."""
+    if importlib.util.find_spec("PySide6") is None:
+        subprocess.run(
+            [sys.executable, "-m", "pip", "install", "PySide6"], check=False
+        )
+
+
+ensure_pyside6()
+
 from PySide6 import QtCore
 
 

--- a/src/run_app.py
+++ b/src/run_app.py
@@ -1,3 +1,7 @@
+from bootstrapper import ensure_pyside6
+
+ensure_pyside6()
+
 from PySide6 import QtWidgets
 from main_window import MainWindow
 from bootstrapper import Bootstrapper


### PR DESCRIPTION
## Summary
- ensure `PySide6` is installed before any GUI code runs
- show in README that PySide6 is installed first when bootstrapping
- describe new behaviour in changelog

## Testing
- `pytest -q`