### PR TITLE
Add keyword search GUI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable changes to this project will be documented in this file.
 - Runtime bootstrapper installs dependencies listed in `requirements.txt` at
   startup with a progress dialog before launching the main window.
 - Uninstaller removes packages installed by the bootstrapper during uninstall.
+- Main window loads keywords from the path in `Settings` and provides a search
+  bar plus a **Find Editorials** button to display matching transcript segments.
 
 ### Changed
 - Bootstrapper now installs PySide6 first so the progress window can launch

--- a/README.md
+++ b/README.md
@@ -49,6 +49,13 @@ The `ClipExporter` in `src/clip_exporter.py` wraps ffmpeg-python and provides
 Timestamped transcription segments are generated in `src/transcribe_worker.py` using the Whisper library. Speaker labeling is performed in `src/diarizer.py` with `pyannote.audio`. The diarization model loads only when speaker tags are first needed. See the unit tests in `tests/` for basic usage.
 The `TranscriptAggregator` in `src/transcript_aggregator.py` can merge these segment lists into a single timeline.
 
+## Using the Keyword Search
+
+Below the file list is a search bar with **Search** and **Find Editorials** buttons.
+Enter text in the bar and click **Search** to show transcript segments containing
+that phrase. **Find Editorials** lists segments matching any keywords loaded from
+`keywords.json`. Results appear in a pane beneath the transcript.
+
 ## 4 — If an AI Agent Will Write the Code
 
 - Supply acceptance tests (pytest) that cover every feature above.


### PR DESCRIPTION
## Summary
- hook up keyword index via Settings
- expose search bar & editorial finder on the main window
- show matching segments in results pane
- document the new keyword search interface
- keep changelog up to date
- extend tests for keyword search/editorial finders

## Testing
- `pytest -q`