### PR TITLE
Add export buttons and segment clip feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ All notable changes to this project will be documented in this file.
 - Uninstaller removes packages installed by the bootstrapper during uninstall.
 - Main window loads keywords from the path in `Settings` and provides a search
   bar plus a **Find Editorials** button to display matching transcript segments.
+- Export buttons allow saving the full transcript as TXT, JSON or SRT. A
+  highlighted segment can be saved along with a clipped audio file.
 
 ### Changed
 - Bootstrapper now installs PySide6 first so the progress window can launch

--- a/README.md
+++ b/README.md
@@ -56,6 +56,17 @@ Enter text in the bar and click **Search** to show transcript segments containin
 that phrase. **Find Editorials** lists segments matching any keywords loaded from
 `keywords.json`. Results appear in a pane beneath the transcript.
 
+## Exporting Transcripts
+
+Below the search bar is a row of **Export** buttons.
+
+- **Export TXT**, **Export JSON** and **Export SRT** save the entire transcript
+  in the chosen format. After clicking, select the destination path in the file
+  dialog.
+- To export a single segment, highlight its line in the transcript and click
+  **Export Segment**. The text is written to the selected ``.txt`` file and a
+  clipped ``.wav`` with the same base name is created.
+
 ## 4 — If an AI Agent Will Write the Code
 
 - Supply acceptance tests (pytest) that cover every feature above.


### PR DESCRIPTION
## Summary
- add export buttons to main window for TXT, JSON, and SRT
- implement segment export with audio clipping via `ClipExporter`
- document export instructions in README
- update changelog
- add tests exercising export actions

## Testing
- `pytest -q`