### PR TITLE
Enable drag-drop reordering and sequential processing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ All notable changes to this project will be documented in this file.
   bar plus a **Find Editorials** button to display matching transcript segments.
 - Export buttons allow saving the full transcript as TXT, JSON or SRT. A
   highlighted segment can be saved along with a clipped audio file.
+- File list now allows drag-and-drop reordering, and processing respects the
+  arranged sequence.
 
 ### Changed
 - Bootstrapper now installs PySide6 first so the progress window can launch

--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@
 - On startup, the bootstrapper first ensures PySide6 is installed so the Qt
   progress window can launch. The window then installs any remaining
   dependencies with a progress bar before starting the main application.
-- Accept multiple audio files (browse or drag-drop) and let the user re-order them.
+- Accept multiple audio files (browse or drag-drop). The file list supports
+  drag-and-drop reordering and files are processed in that sequence.
 - Perform local Whisper sentence-level transcription with timestamps and Speaker 1/2/3 tags (users can rename later).
 - Display live transcript plus a per-file progress bar during processing.
 - After all files finish, enable keyword search and a “Find all editorials” button using a persistent keyword list.


### PR DESCRIPTION
## Summary
- allow internal drag & drop reordering of the file list
- process files sequentially according to the user-defined order
- document reordering capability in the README
- log the feature in the changelog
- extend tests to cover new ordering logic

## Testing
- `pytest -q`