### PR TITLE
Implement settings dialog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist/
 build/
 .pytest_cache/
 .mypy_cache/
+out.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,11 @@ All notable changes to this project will be documented in this file.
 - Export buttons allow saving the full transcript as TXT, JSON or SRT. A
   highlighted segment can be saved along with a clipped audio file.
 - File list now allows drag-and-drop reordering, and processing respects the
-  arranged sequence.
+    arranged sequence.
 - Rename Speakers dialog allows updating speaker labels and exports reflect the
-  new names.
+    new names.
+- Settings dialog allows changing the keyword list path and UI preferences with
+    saved values reloaded on restart.
 
 ### Changed
 - Bootstrapper now installs PySide6 first so the progress window can launch

--- a/README.md
+++ b/README.md
@@ -73,6 +73,14 @@ Click **Rename Speakers** to change the automatically detected speaker labels.
 Each name is shown in a prompt where you can enter a new label. The transcript
 pane and any exports will reflect the updated names.
 
+## Configuration
+
+Use the **Settings** button to adjust application options. The dialog lets you
+choose a new path for `keywords.json` and edit UI preferences such as the
+`theme` setting. Changes are saved to
+`%APPDATA%\WhisperTranscriber\settings.json` and take effect the next time the
+application is launched.
+
 ## 4 — If an AI Agent Will Write the Code
 
 - Supply acceptance tests (pytest) that cover every feature above.

--- a/tests/test_settings_dialog.py
+++ b/tests/test_settings_dialog.py
@@ -1,0 +1,40 @@
+import os
+import sys
+import importlib
+import types
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+from test_main_window import make_pyside6_stub
+
+
+def test_settings_dialog_updates_and_persists(monkeypatch, tmp_path):
+    stubs = make_pyside6_stub()
+    for name, module in stubs.items():
+        monkeypatch.setitem(sys.modules, name, module)
+
+    settings_mod = importlib.import_module('settings')
+    settings_mod = importlib.reload(settings_mod)
+    path = tmp_path / 'settings.json'
+    settings = settings_mod.Settings(str(path))
+
+    tw = types.ModuleType('transcribe_worker'); tw.TranscribeWorker = lambda *a, **k: None
+    dr = types.ModuleType('diarizer'); dr.Diarizer = lambda *a, **k: None
+    kw = types.ModuleType('keyword_index'); kw.KeywordIndex = lambda p: types.SimpleNamespace(search=lambda s,q: [], find_all_editorial=lambda s: [])
+    ce = types.ModuleType('clip_exporter'); ce.ClipExporter = lambda: types.SimpleNamespace()
+    monkeypatch.setitem(sys.modules, 'transcribe_worker', tw)
+    monkeypatch.setitem(sys.modules, 'diarizer', dr)
+    monkeypatch.setitem(sys.modules, 'keyword_index', kw)
+    monkeypatch.setitem(sys.modules, 'clip_exporter', ce)
+
+    mw_module = importlib.import_module('main_window')
+    mw_module = importlib.reload(mw_module)
+
+    dialog = mw_module.SettingsDialog(settings)
+    dialog.keyword_edit.setText(str(tmp_path / 'kw.json'))
+    dialog.theme_edit.setText('dark')
+    dialog.accept()
+
+    settings.save()
+    loaded = settings_mod.Settings(str(path))
+    assert loaded.keyword_path == str(tmp_path / 'kw.json')
+    assert loaded.ui['theme'] == 'dark'


### PR DESCRIPTION
## Summary
- add a simple SettingsDialog for editing keyword path and theme
- expose Settings button in the main window
- persist Settings through the dialog
- document the new configuration options
- log the change
- test SettingsDialog and persistence

## Testing
- `pytest -q`