### PR TITLE
Add PDF user guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ All notable changes to this project will be documented in this file.
     arranged sequence.
 - Rename Speakers dialog allows updating speaker labels and exports reflect the
     new names.
+- Concise PDF user guide covers installation, usage, exporting, keyword
+  management and uninstallation.
 - Settings dialog allows changing the keyword list path and UI preferences with
     saved values reloaded on restart.
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ application is launched.
 
 - Signed Windows installer (.exe)
 - Source repository with tests, prompts, and README
-- One-page user guide (PDF)
+- [User Guide](docs/user_guide.pdf)
 
 That’s the entire plan—feature set, tech choices, modules, and deliverables—without any timelines.
 

--- a/docs/user_guide.pdf
+++ b/docs/user_guide.pdf
@@ -1,0 +1,71 @@
+%PDF-1.4
+1 0 obj
+<<
+/Type /Catalog
+/Pages 2 0 R
+>>
+endobj
+2 0 obj
+<<
+/Type /Pages
+/Kids [3 0 R]
+/Count 1
+>>
+endobj
+3 0 obj
+<<
+/Type /Page
+/Parent 2 0 R
+/MediaBox [0 0 612 792]
+/Contents 4 0 R
+/Resources <<
+/Font << /F1 5 0 R >>
+>>
+>>
+endobj
+4 0 obj
+<<
+/Length 828
+>>
+stream
+BT
+/F1 18 Tf
+72 760 Td (Whisper Transcriber User Guide) Tj
+/F1 12 Tf
+72 732 Td (Installation:) Tj
+72 718 Td (1. Install Python and FFmpeg.) Tj
+72 704 Td (2. Run 'python build_installer.py' to create the executable.) Tj
+72 690 Td (3. Launch the installer from 'dist/'.) Tj
+72 660 Td (Basic Usage:) Tj
+72 646 Td (1. Drag audio files into the file list in order.) Tj
+72 632 Td (2. Click 'Transcribe' to process the files.) Tj
+72 618 Td (3. Search or highlight segments in the transcript.) Tj
+72 588 Td (Exporting:) Tj
+72 574 Td (Use the Export buttons to save TXT, JSON, SRT, or a clipped audio segment.) Tj
+72 544 Td (Keyword Management:) Tj
+72 530 Td (Edit 'keywords.json' via the Settings dialog to update search terms.) Tj
+72 500 Td (Uninstallation:) Tj
+72 486 Td (Run 'python src/uninstaller.py' to remove dependencies.) Tj
+ET
+endstream
+endobj
+5 0 obj
+<<
+/Type /Font
+/Subtype /Type1
+/BaseFont /Helvetica
+>>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000009 00000 n 
+0000000058 00000 n 
+0000000115 00000 n 
+0000000241 00000 n 
+0000001120 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+1190
+%%EOF


### PR DESCRIPTION
## Summary
- include docs/user_guide.pdf with installation, usage, export, keyword and uninstall instructions
- reference the PDF from README
- document the addition in CHANGELOG

## Testing
- `pytest -q`