### PR TITLE
Fix NSIS uninstaller call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,4 +26,6 @@ All notable changes to this project will be documented in this file.
 ### Changed
 - Bootstrapper now installs PySide6 first so the progress window can launch
   before installing remaining dependencies.
+- Uninstaller now invokes the bundled Python interpreter via
+  `WhisperTranscriber.exe uninstaller.py` instead of calling `$INSTDIR\python.exe`.
 

--- a/installer/whisper_transcriber.nsi
+++ b/installer/whisper_transcriber.nsi
@@ -13,7 +13,7 @@ Section "MainSection" SEC01
 SectionEnd
 
 Section "Uninstall"
-    Exec '"$INSTDIR\python.exe" "$INSTDIR\uninstaller.py"'
+    Exec '"$INSTDIR\WhisperTranscriber.exe" "uninstaller.py"'
     Delete "$INSTDIR\WhisperTranscriber.exe"
     Delete "$INSTDIR\Uninstall.exe"
     RMDir "$INSTDIR"


### PR DESCRIPTION
## Summary
- call bundled `WhisperTranscriber.exe` in NSIS uninstall section
- note change in changelog

## Testing
- `pytest -q`
- *(installer test skipped: NSIS not available)*