### PR TITLE
Add contributor prompts and checklist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,3 +31,12 @@ All notable changes to this project will be documented in this file.
 - Uninstaller now invokes the bundled Python interpreter via
   `WhisperTranscriber.exe uninstaller.py` instead of calling `$INSTDIR\python.exe`.
 
+
+## [0.1.0] - 2025-05-28
+### Added
+- Created `prompts/` directory at the repository root.
+- Added `prompts/system_prompt.txt` defining the system prompt.
+- Added `prompts/developer_prompt.txt` with developer instructions.
+- Added `prompts/contributor_tasks.txt` describing tasks for contributors.
+- Introduced `self_review_checklist.md` to outline verification steps.
+- README now links to the prompts directory and the checklist.

--- a/README.md
+++ b/README.md
@@ -116,6 +116,18 @@ The resulting executable will be placed in the `dist/` directory. The
 `installer/whisper_transcriber.nsi` script can then be adapted to wrap this
 binary in an NSIS installer.
 
+## Contributor Resources
+
+The `prompts/` directory contains text prompts used by the automation
+agents:
+
+- `prompts/system_prompt.txt`
+- `prompts/developer_prompt.txt`
+- `prompts/contributor_tasks.txt`
+
+Guidelines for verifying changes before submission are provided in
+[`self_review_checklist.md`](self_review_checklist.md).
+
 ## License
 
 This project is licensed under the MIT License. See [LICENSE](LICENSE) for details.

--- a/prompts/contributor_tasks.txt
+++ b/prompts/contributor_tasks.txt
@@ -1,0 +1,3 @@
+- Review `self_review_checklist.md` before opening a pull request.
+- Add tests for new features and update documentation.
+- Describe changes in `CHANGELOG.md`.

--- a/prompts/developer_prompt.txt
+++ b/prompts/developer_prompt.txt
@@ -1,0 +1,1 @@
+When writing code for Whisper Transcriber, follow Python best practices, keep modules loosely coupled and add docstrings to public functions.

--- a/prompts/system_prompt.txt
+++ b/prompts/system_prompt.txt
@@ -1,0 +1,1 @@
+You are the automation agent for Whisper Transcriber. Provide concise and relevant answers about the project.

--- a/self_review_checklist.md
+++ b/self_review_checklist.md
@@ -1,0 +1,9 @@
+# Self Review Checklist
+
+Before submitting a pull request:
+
+1. Run `pytest` and ensure all tests pass.
+2. Update `README.md` and `CHANGELOG.md` when introducing or removing features.
+3. Confirm new files are committed to version control.
+4. Check that prompts in `prompts/` are kept up to date.
+5. Perform a manual smoke test of the application.


### PR DESCRIPTION
## Summary
- add `prompts/` directory for automation
- create system, developer, and contributor task prompts
- add `self_review_checklist.md`
- document prompts and checklist in README
- record new version in CHANGELOG

## Testing
- `pytest -q`