### PR TITLE
Add keywords sample and docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ All notable changes to this project will be documented in this file.
     saved values reloaded on restart.
 - Tests now verify that `ensure_pyside6()` installs PySide6 only when it's
   missing.
+- Example `keywords.json` added in `docs/` and README updated with instructions
+  for loading or editing it via the Settings dialog.
 
 ### Changed
 - Bootstrapper now installs PySide6 first so the progress window can launch

--- a/README.md
+++ b/README.md
@@ -77,7 +77,9 @@ pane and any exports will reflect the updated names.
 
 Use the **Settings** button to adjust application options. The dialog lets you
 choose a new path for `keywords.json` and edit UI preferences such as the
-`theme` setting. Changes are saved to
+`theme` setting. An example file is provided at `docs/keywords.json`. Load this
+file or edit it to include your own terms by browsing to its location in the
+Settings dialog. Changes are saved to
 `%APPDATA%\WhisperTranscriber\settings.json` and take effect the next time the
 application is launched.
 

--- a/docs/keywords.json
+++ b/docs/keywords.json
@@ -1,0 +1,5 @@
+[
+  "sponsor",
+  "advertisement",
+  "paid placement"
+]


### PR DESCRIPTION
## Summary
- add a sample `keywords.json`
- document how to load or edit the file via the Settings dialog
- mention the sample in the changelog

## Testing
- `pytest -q`