### PR TITLE
Fix incomplete user guide PDF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Whenever a feature is added or removed, update the "Unreleased" section with a d
 ### Added
 
 ### Changed
+ - Regenerated `docs/user_guide.pdf` so the full instructions display
+   correctly in standard PDF viewers.
 
 ## [0.1.0] – YYYY-MM-DD
 ### Added

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ application is launched.
 
 - Signed Windows installer (.exe)
 - Source repository with tests, prompts, and README
-- [User Guide](docs/user_guide.pdf)
+- [User Guide](docs/user_guide.pdf) with installation and usage instructions
 
 That’s the entire plan—feature set, tech choices, modules, and deliverables—without any timelines.
 

--- a/docs/user_guide.pdf
+++ b/docs/user_guide.pdf
@@ -1,32 +1,18 @@
 %PDF-1.4
 1 0 obj
-<<
-/Type /Catalog
-/Pages 2 0 R
->>
+<< /Type /Catalog /Pages 2 0 R >>
 endobj
 2 0 obj
-<<
-/Type /Pages
-/Kids [3 0 R]
-/Count 1
->>
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
 endobj
 3 0 obj
-<<
-/Type /Page
-/Parent 2 0 R
-/MediaBox [0 0 612 792]
-/Contents 4 0 R
-/Resources <<
-/Font << /F1 5 0 R >>
->>
->>
+<< /Type /Page /Parent 2 0 R /Resources << /Font << /F1 4 0 R >> >> /MediaBox [0 0 612 792] /Contents 5 0 R >>
 endobj
 4 0 obj
-<<
-/Length 828
->>
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+5 0 obj
+<< /Length 828 >>
 stream
 BT
 /F1 18 Tf
@@ -36,25 +22,18 @@ BT
 72 718 Td (1. Install Python and FFmpeg.) Tj
 72 704 Td (2. Run 'python build_installer.py' to create the executable.) Tj
 72 690 Td (3. Launch the installer from 'dist/'.) Tj
-72 660 Td (Basic Usage:) Tj
-72 646 Td (1. Drag audio files into the file list in order.) Tj
-72 632 Td (2. Click 'Transcribe' to process the files.) Tj
-72 618 Td (3. Search or highlight segments in the transcript.) Tj
-72 588 Td (Exporting:) Tj
-72 574 Td (Use the Export buttons to save TXT, JSON, SRT, or a clipped audio segment.) Tj
-72 544 Td (Keyword Management:) Tj
-72 530 Td (Edit 'keywords.json' via the Settings dialog to update search terms.) Tj
-72 500 Td (Uninstallation:) Tj
-72 486 Td (Run 'python src/uninstaller.py' to remove dependencies.) Tj
+72 662 Td (Basic Usage:) Tj
+72 648 Td (1. Drag audio files into the file list in order.) Tj
+72 634 Td (2. Click 'Transcribe' to process the files.) Tj
+72 620 Td (3. Search or highlight segments in the transcript.) Tj
+72 592 Td (Exporting:) Tj
+72 578 Td (Use the Export buttons to save TXT, JSON, SRT, or a clipped audio segment.) Tj
+72 550 Td (Keyword Management:) Tj
+72 536 Td (Edit 'keywords.json' via the Settings dialog to update search terms.) Tj
+72 508 Td (Uninstallation:) Tj
+72 494 Td (Run 'python src/uninstaller.py' to remove dependencies.) Tj
 ET
 endstream
-endobj
-5 0 obj
-<<
-/Type /Font
-/Subtype /Type1
-/BaseFont /Helvetica
->>
 endobj
 xref
 0 6
@@ -63,9 +42,8 @@ xref
 0000000058 00000 n 
 0000000115 00000 n 
 0000000241 00000 n 
-0000001120 00000 n 
-trailer
-<< /Size 6 /Root 1 0 R >>
+0000000311 00000 n 
+trailer << /Size 6 /Root 1 0 R >>
 startxref
 1190
 %%EOF

--- a/scripts/generate_user_guide_pdf.py
+++ b/scripts/generate_user_guide_pdf.py
@@ -1,0 +1,76 @@
+import io
+
+CONTENT_LINES = [
+    "Whisper Transcriber User Guide",
+    "",
+    "Installation:",
+    "1. Install Python and FFmpeg.",
+    "2. Run 'python build_installer.py' to create the executable.",
+    "3. Launch the installer from 'dist/'.",
+    "",
+    "Basic Usage:",
+    "1. Drag audio files into the file list in order.",
+    "2. Click 'Transcribe' to process the files.",
+    "3. Search or highlight segments in the transcript.",
+    "",
+    "Exporting:",
+    "Use the Export buttons to save TXT, JSON, SRT, or a clipped audio segment.",
+    "",
+    "Keyword Management:",
+    "Edit 'keywords.json' via the Settings dialog to update search terms.",
+    "",
+    "Uninstallation:",
+    "Run 'python src/uninstaller.py' to remove dependencies."
+]
+
+def create_content_stream():
+    lines = []
+    y = 760
+    lines.append("BT")
+    lines.append("/F1 18 Tf")
+    lines.append(f"72 {y} Td ({CONTENT_LINES[0]}) Tj")
+    lines.append("/F1 12 Tf")
+    y -= 28
+    for line in CONTENT_LINES[2:]:
+        if not line:
+            y -= 14
+            continue
+        lines.append(f"72 {y} Td ({line}) Tj")
+        y -= 14
+    lines.append("ET")
+    return "\n".join(lines)
+
+def generate_pdf(path):
+    objects = []
+    content_stream = create_content_stream()
+    objects.append("<< /Type /Catalog /Pages 2 0 R >>")
+    objects.append("<< /Type /Pages /Kids [3 0 R] /Count 1 >>")
+    objects.append(
+        "<< /Type /Page /Parent 2 0 R /Resources << /Font << /F1 4 0 R >> >> /MediaBox [0 0 612 792] /Contents 5 0 R >>"
+    )
+    objects.append("<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>")
+    objects.append(f"<< /Length {len(content_stream)} >>\nstream\n{content_stream}\nendstream")
+
+    pdf = io.BytesIO()
+    pdf.write(b"%PDF-1.4\n")
+    offsets = []
+    for idx, obj in enumerate(objects, 1):
+        offsets.append(pdf.tell())
+        pdf.write(f"{idx} 0 obj\n{obj}\nendobj\n".encode("latin-1"))
+
+    xref_pos = pdf.tell()
+    pdf.write(f"xref\n0 {len(objects)+1}\n".encode("latin-1"))
+    pdf.write(b"0000000000 65535 f \n")
+    for off in offsets:
+        pdf.write(f"{off:010d} 00000 n \n".encode("latin-1"))
+    pdf.write(
+        f"trailer << /Size {len(objects)+1} /Root 1 0 R >>\nstartxref\n{xref_pos}\n%%EOF".encode(
+            "latin-1"
+        )
+    )
+
+    with open(path, "wb") as f:
+        f.write(pdf.getvalue())
+
+if __name__ == "__main__":
+    generate_pdf("docs/user_guide.pdf")


### PR DESCRIPTION
## Summary
- rebuild `docs/user_guide.pdf` with complete instructions
- document the PDF generation script
- note the documentation fix in the changelog

## Testing
- `pytest -q`
- `python -m src.run_app --help` *(fails: ModuleNotFoundError: No module named 'ffmpeg')*
