### PR TITLE
Fix PyInstaller path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Whenever a feature is added or removed, update the "Unreleased" section with a d
  - Replaced `docs/user_guide.pdf` with a plain-text version. The generator
    script now writes `docs/user_guide.txt` instead of a PDF and the PDF file was
    removed from the repository.
+ - `build_installer.py` now passes `--paths src` to `PyInstaller.__main__.run`
+   so bundled executables can import the `bootstrapper` module without errors.
 
 ## [0.1.0] – YYYY-MM-DD
 ### Added

--- a/build_installer.py
+++ b/build_installer.py
@@ -7,6 +7,8 @@ def main() -> None:
     PyInstaller.__main__.run(
         [
             "src/run_app.py",
+            "--paths",
+            "src",
             "--name=WhisperTranscriber",
             "--onefile",
             "--windowed",


### PR DESCRIPTION
## Notes
- Added `--paths src` when calling PyInstaller to ensure modules in `src/` are bundled.
- Documented the change in CHANGELOG.

## Testing
- `pytest -q`