### PR TITLE
Add automatic ffmpeg-python install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Whenever a feature is added or removed, update the "Unreleased" section with a d
 ## [Unreleased]
 ### Added
 - `ensure_ffmpeg()` installs `ffmpeg-static` automatically when FFmpeg is not present.
+- `ensure_ffmpeg()` installs `ffmpeg-python` automatically when the Python wrapper is missing.
 
 ### Changed
  - Replaced `docs/user_guide.pdf` with a plain-text version. The generator

--- a/README.md
+++ b/README.md
@@ -3,8 +3,10 @@
 ## 1 — Core Functionality
 
 - On startup, the bootstrapper first ensures PySide6 and FFmpeg are installed so the Qt
-  progress window can launch. The window then installs any remaining
-  dependencies with a progress bar before starting the main application.
+  progress window can launch. This includes installing `ffmpeg-static` for the
+  executable and `ffmpeg-python` for the wrapper if they are missing. The window
+  then installs any remaining dependencies with a progress bar before starting
+  the main application.
 - Accept multiple audio files (browse or drag-drop). The file list supports
   drag-and-drop reordering and files are processed in that sequence.
 - Perform local Whisper sentence-level transcription with timestamps and Speaker 1/2/3 tags (users can rename later).

--- a/src/bootstrapper.py
+++ b/src/bootstrapper.py
@@ -21,10 +21,14 @@ ensure_pyside6()
 
 
 def ensure_ffmpeg() -> None:
-    """Install FFmpeg if it's not already available."""
+    """Install FFmpeg and its Python wrapper if they're not available."""
     if shutil.which("ffmpeg") is None:
         subprocess.run(
             [sys.executable, "-m", "pip", "install", "ffmpeg-static"], check=False
+        )
+    if importlib.util.find_spec("ffmpeg") is None:
+        subprocess.run(
+            [sys.executable, "-m", "pip", "install", "ffmpeg-python"], check=False
         )
 
 


### PR DESCRIPTION
## Summary
- install `ffmpeg-python` automatically if its module is missing
- expect `ffmpeg-python` install in bootstrapper tests
- clarify ffmpeg auto-install in README
- document ffmpeg-python install in CHANGELOG

## Testing
- `pytest -q`