### PR TITLE
Introduce pip helpers for installation and uninstall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Whenever a feature is added or removed, update the "Unreleased" section with a d
 ### Added
 - `ensure_ffmpeg()` installs `ffmpeg-static` automatically when FFmpeg is not present.
 - `ensure_ffmpeg()` installs `ffmpeg-python` automatically when the Python wrapper is missing.
+- `pip_install()` and `pip_uninstall()` helper functions manage package installation and removal without spawning subprocesses.
 
 ### Changed
  - Replaced `docs/user_guide.pdf` with a plain-text version. The generator
@@ -14,6 +15,8 @@ Whenever a feature is added or removed, update the "Unreleased" section with a d
    removed from the repository.
  - `build_installer.py` now passes `--paths src` to `PyInstaller.__main__.run`
    so bundled executables can import the `bootstrapper` module without errors.
+ - `bootstrapper` and `uninstaller` now use the new helper functions instead
+   of invoking `subprocess.run` with `sys.executable -m pip`.
 
 ## [0.1.0] – YYYY-MM-DD
 ### Added

--- a/src/bootstrapper.py
+++ b/src/bootstrapper.py
@@ -9,12 +9,17 @@ import importlib.util
 import shutil
 
 
+def pip_install(package: str) -> int:
+    """Install *package* using pip's internal API."""
+    from pip._internal.cli.main import main as pip_main
+
+    return pip_main(["install", package])
+
+
 def ensure_pyside6() -> None:
     """Install PySide6 if it's not already available."""
     if importlib.util.find_spec("PySide6") is None:
-        subprocess.run(
-            [sys.executable, "-m", "pip", "install", "PySide6"], check=False
-        )
+        pip_install("PySide6")
 
 
 ensure_pyside6()
@@ -23,13 +28,9 @@ ensure_pyside6()
 def ensure_ffmpeg() -> None:
     """Install FFmpeg and its Python wrapper if they're not available."""
     if shutil.which("ffmpeg") is None:
-        subprocess.run(
-            [sys.executable, "-m", "pip", "install", "ffmpeg-static"], check=False
-        )
+        pip_install("ffmpeg-static")
     if importlib.util.find_spec("ffmpeg") is None:
-        subprocess.run(
-            [sys.executable, "-m", "pip", "install", "ffmpeg-python"], check=False
-        )
+        pip_install("ffmpeg-python")
 
 
 ensure_ffmpeg()
@@ -66,7 +67,7 @@ class Bootstrapper(QtCore.QThread):
         missing = self._missing_packages(pkgs)
         total = len(missing)
         for i, pkg in enumerate(missing):
-            subprocess.run([sys.executable, '-m', 'pip', 'install', pkg], check=False)
+            pip_install(pkg)
             if total:
                 self.progress.emit((i + 1) / total)
         self.finished.emit()

--- a/src/uninstaller.py
+++ b/src/uninstaller.py
@@ -7,13 +7,20 @@ import sys
 import subprocess
 
 
+def pip_uninstall(package: str) -> int:
+    """Uninstall *package* using pip's internal API."""
+    from pip._internal.cli.main import main as pip_main
+
+    return pip_main(["uninstall", "-y", package])
+
+
 def uninstall_packages(requirements_path: str) -> None:
     """Read ``requirements_path`` and uninstall each package listed."""
     with open(requirements_path, 'r', encoding='utf-8') as fh:
         packages = [line.strip() for line in fh if line.strip() and not line.startswith('#')]
 
     for pkg in packages:
-        subprocess.run([sys.executable, '-m', 'pip', 'uninstall', '-y', pkg], check=False)
+        pip_uninstall(pkg)
 
 
 if __name__ == '__main__':  # pragma: no cover - used by installer

--- a/tests/test_uninstaller.py
+++ b/tests/test_uninstaller.py
@@ -11,19 +11,13 @@ def test_uninstall_packages_invokes_pip(monkeypatch, tmp_path):
 
     runs = []
 
-    def fake_run(args, check=False):
-        runs.append(args)
-
-    import subprocess
-    monkeypatch.setattr(subprocess, 'run', fake_run)
+    def fake_uninstall(pkg):
+        runs.append(pkg)
 
     mod = importlib.import_module('uninstaller')
     mod = importlib.reload(mod)
+    monkeypatch.setattr(mod, 'pip_uninstall', fake_uninstall)
     mod.uninstall_packages(str(req))
 
-    expected = [
-        [sys.executable, '-m', 'pip', 'uninstall', '-y', 'pkgA'],
-        [sys.executable, '-m', 'pip', 'uninstall', '-y', 'pkgB==1.2'],
-        [sys.executable, '-m', 'pip', 'uninstall', '-y', 'pkgC'],
-    ]
+    expected = ['pkgA', 'pkgB==1.2', 'pkgC']
     assert runs == expected


### PR DESCRIPTION
## Summary
- replace subprocess pip calls with `pip_install()` helper in the bootstrapper
- add matching `pip_uninstall()` helper in the uninstaller
- update tests to patch the new helper mechanism
- document helper functions in the changelog

## Testing
- `pytest -q`
- `python build_installer.py` *(fails: ModuleNotFoundError: No module named 'PyInstaller')*