### PR TITLE
Fix PyInstaller bundling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,10 @@ Whenever a feature is added or removed, update the "Unreleased" section with a d
    removed from the repository.
  - `build_installer.py` now passes `--paths src` to `PyInstaller.__main__.run`
    so bundled executables can import the `bootstrapper` module without errors.
- - `bootstrapper` and `uninstaller` now use the new helper functions instead
-   of invoking `subprocess.run` with `sys.executable -m pip`.
+- `bootstrapper` and `uninstaller` now use the new helper functions instead
+  of invoking `subprocess.run` with `sys.executable -m pip`.
+- Bundled PyInstaller executable now includes pip's internal `install` and
+  `uninstall` command modules to avoid `ModuleNotFoundError`.
 
 ## [0.1.0] – YYYY-MM-DD
 ### Added

--- a/build_installer.py
+++ b/build_installer.py
@@ -13,6 +13,8 @@ def main() -> None:
             "--onefile",
             "--windowed",
             "--noconfirm",
+            "--hidden-import=pip._internal.commands.install",
+            "--hidden-import=pip._internal.commands.uninstall",
             "--distpath",
             "dist",
         ]


### PR DESCRIPTION
## Summary
- bundle pip install/uninstall command modules so built exe doesn't fail
- document PyInstaller bundling change in changelog

## Testing
- `pytest -q`
- `python build_installer.py` *(fails: ModuleNotFoundError: No module named 'PyInstaller')*