### PR TITLE
Bundle pip CA bundle in installer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ Whenever a feature is added or removed, update the "Unreleased" section with a d
   of invoking `subprocess.run` with `sys.executable -m pip`.
 - Bundled PyInstaller executable now includes pip's internal `install` and
   `uninstall` command modules to avoid `ModuleNotFoundError`.
+- Installer now bundles pip's CA bundle to avoid `FileNotFoundError` when
+  pip looks for its certificates at runtime.
 
 ## [0.1.0] – YYYY-MM-DD
 ### Added

--- a/build_installer.py
+++ b/build_installer.py
@@ -1,9 +1,12 @@
 """Builds a standalone Whisper Transcriber executable using PyInstaller."""
 
+import os
 import PyInstaller.__main__
+import pip._vendor.certifi
 
 
 def main() -> None:
+    cert_path = pip._vendor.certifi.where()
     PyInstaller.__main__.run(
         [
             "src/run_app.py",
@@ -15,6 +18,8 @@ def main() -> None:
             "--noconfirm",
             "--hidden-import=pip._internal.commands.install",
             "--hidden-import=pip._internal.commands.uninstall",
+            "--hidden-import=pip._vendor.certifi",
+            f"--add-data={cert_path}{os.pathsep}pip/_vendor/certifi",
             "--distpath",
             "dist",
         ]


### PR DESCRIPTION
## Summary
- bundle pip's certificates with the PyInstaller build
- document bundling certifi's CA bundle to avoid runtime errors

## Testing
- `pytest -q`
- `python build_installer.py` *(fails: ModuleNotFoundError: No module named 'PyInstaller')*