### PR TITLE
Bundle pip CA bundle in installer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ Whenever a feature is added or removed, update the "Unreleased" section with a d
   of invoking `subprocess.run` with `sys.executable -m pip`.
 - Bundled PyInstaller executable now includes pip's internal `install` and
   `uninstall` command modules to avoid `ModuleNotFoundError`.
+- Installer now bundles pip's CA bundle to avoid `FileNotFoundError` when
+  pip looks for its certificates at runtime.
+- `pip_install()` and `pip_uninstall()` now patch distlib to work with
+  PyInstaller's frozen importer, preventing `Unable to locate finder for`
+  errors during runtime installations.
 
 ## [0.1.0] – YYYY-MM-DD
 ### Added

--- a/build_installer.py
+++ b/build_installer.py
@@ -1,9 +1,12 @@
 """Builds a standalone Whisper Transcriber executable using PyInstaller."""
 
+import os
 import PyInstaller.__main__
+import pip._vendor.certifi
 
 
 def main() -> None:
+    cert_path = pip._vendor.certifi.where()
     PyInstaller.__main__.run(
         [
             "src/run_app.py",
@@ -15,6 +18,8 @@ def main() -> None:
             "--noconfirm",
             "--hidden-import=pip._internal.commands.install",
             "--hidden-import=pip._internal.commands.uninstall",
+            "--hidden-import=pip._vendor.certifi",
+            f"--add-data={cert_path}{os.pathsep}pip/_vendor/certifi",
             "--distpath",
             "dist",
         ]

--- a/src/bootstrapper.py
+++ b/src/bootstrapper.py
@@ -13,6 +13,25 @@ def pip_install(package: str) -> int:
     """Install *package* using pip's internal API."""
     from pip._internal.cli.main import main as pip_main
 
+    try:  # register PyInstaller's loader so distlib works in a frozen app
+        import pip._vendor.distlib.resources as dist_resources
+        import importlib.machinery
+
+        dist_resources._finder_registry[importlib.machinery.FrozenImporter] = (
+            dist_resources.ResourceFinder
+        )
+
+        try:
+            from PyInstaller.loader import pyimod02_importers
+
+            dist_resources._finder_registry[
+                pyimod02_importers.FrozenImporter
+            ] = dist_resources.ResourceFinder
+        except Exception:
+            pass
+    except Exception:  # pragma: no cover - defensive
+        pass
+
     return pip_main(["install", package])
 
 

--- a/src/uninstaller.py
+++ b/src/uninstaller.py
@@ -11,6 +11,25 @@ def pip_uninstall(package: str) -> int:
     """Uninstall *package* using pip's internal API."""
     from pip._internal.cli.main import main as pip_main
 
+    try:  # register PyInstaller's loader so distlib works in a frozen app
+        import pip._vendor.distlib.resources as dist_resources
+        import importlib.machinery
+
+        dist_resources._finder_registry[importlib.machinery.FrozenImporter] = (
+            dist_resources.ResourceFinder
+        )
+
+        try:
+            from PyInstaller.loader import pyimod02_importers
+
+            dist_resources._finder_registry[
+                pyimod02_importers.FrozenImporter
+            ] = dist_resources.ResourceFinder
+        except Exception:
+            pass
+    except Exception:  # pragma: no cover - defensive
+        pass
+
     return pip_main(["uninstall", "-y", package])
 
 


### PR DESCRIPTION
## Summary
- bundle pip's certificates with the PyInstaller build
- document bundling certifi's CA bundle to avoid runtime errors
- patch pip's distlib finder when installing/uninstalling packages in frozen mode

## Testing
- `pytest -q`
- `python build_installer.py` *(fails: ModuleNotFoundError: No module named 'PyInstaller')*