### PR TITLE
Bundle distlib module for PyInstaller build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Whenever a feature is added or removed, update the "Unreleased" section with a d
   `uninstall` command modules to avoid `ModuleNotFoundError`.
 - Installer now bundles pip's CA bundle to avoid `FileNotFoundError` when
   pip looks for its certificates at runtime.
+- Installer now bundles `pip._vendor.distlib` to prevent bootstrap errors.
 
 ## [0.1.0] – YYYY-MM-DD
 ### Added

--- a/README.md
+++ b/README.md
@@ -116,6 +116,9 @@ Run the helper script which invokes PyInstaller:
 python build_installer.py
 ```
 
+The script adds `--hidden-import=pip._vendor.distlib` so pip can bootstrap
+correctly. Include the same option if invoking PyInstaller manually.
+
 The resulting executable will be placed in the `dist/` directory. The
 `installer/whisper_transcriber.nsi` script can then be adapted to wrap this
 binary in an NSIS installer.

--- a/build_installer.py
+++ b/build_installer.py
@@ -19,6 +19,7 @@ def main() -> None:
             "--hidden-import=pip._internal.commands.install",
             "--hidden-import=pip._internal.commands.uninstall",
             "--hidden-import=pip._vendor.certifi",
+            "--hidden-import=pip._vendor.distlib",
             f"--add-data={cert_path}{os.pathsep}pip/_vendor/certifi",
             "--distpath",
             "dist",


### PR DESCRIPTION
## Summary
- include `pip._vendor.distlib` as a hidden import in `build_installer.py`
- document the new requirement in the build instructions
- note distlib bundling in the changelog

## Testing
- `pytest -q`