### PR TITLE
Add logging setup with rotating file handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Whenever a feature is added or removed, update the "Unreleased" section with a d
 - `ensure_ffmpeg()` installs `ffmpeg-static` automatically when FFmpeg is not present.
 - `ensure_ffmpeg()` installs `ffmpeg-python` automatically when the Python wrapper is missing.
 - `pip_install()` and `pip_uninstall()` helper functions manage package installation and removal.
+- `setup_logging()` in `src/logging_setup.py` configures rotating file logs under `logs/` and provides `get_logger()`.
 
 ### Changed
  - Replaced `docs/user_guide.pdf` with a plain-text version. The generator

--- a/README.md
+++ b/README.md
@@ -123,6 +123,12 @@ The resulting executable will be placed in the `dist/` directory. The
 `installer/whisper_transcriber.nsi` script can then be adapted to wrap this
 binary in an NSIS installer.
 
+## Log Files
+
+Application logs are written to the `logs/` directory at the repository root.
+`app.log` stores general runtime messages and `installer_build.log` captures
+output from `build_installer.py`.
+
 ## Contributor Resources
 
 The `prompts/` directory contains text prompts used by the automation

--- a/src/logging_setup.py
+++ b/src/logging_setup.py
@@ -1,0 +1,58 @@
+import logging
+import logging.config
+from logging.handlers import RotatingFileHandler
+from pathlib import Path
+
+LOG_DIR = Path(__file__).resolve().parent.parent / "logs"
+APP_LOG = LOG_DIR / "app.log"
+INSTALLER_LOG = LOG_DIR / "installer_build.log"
+
+
+def setup_logging() -> None:
+    """Ensure log directory exists and configure logging handlers."""
+    LOG_DIR.mkdir(parents=True, exist_ok=True)
+
+    config = {
+        "version": 1,
+        "formatters": {
+            "default": {
+                "format": "%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+            }
+        },
+        "handlers": {
+            "app_file": {
+                "class": "logging.handlers.RotatingFileHandler",
+                "filename": str(APP_LOG),
+                "maxBytes": 1_000_000,
+                "backupCount": 3,
+                "formatter": "default",
+                "encoding": "utf-8",
+            },
+            "installer_file": {
+                "class": "logging.handlers.RotatingFileHandler",
+                "filename": str(INSTALLER_LOG),
+                "maxBytes": 1_000_000,
+                "backupCount": 3,
+                "formatter": "default",
+                "encoding": "utf-8",
+            },
+        },
+        "root": {
+            "handlers": ["app_file"],
+            "level": "INFO",
+        },
+        "loggers": {
+            "build_installer": {
+                "handlers": ["installer_file"],
+                "level": "INFO",
+                "propagate": False,
+            }
+        },
+    }
+
+    logging.config.dictConfig(config)
+
+
+def get_logger(name: str) -> logging.Logger:
+    """Return a logger instance."""
+    return logging.getLogger(name)


### PR DESCRIPTION
## Summary
- add `src/logging_setup.py` with `setup_logging()` and `get_logger()` helpers
- describe log file locations in README
- document new logging system in CHANGELOG

## Testing
- `pytest -q`