### PR TITLE
Add logging across modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Whenever a feature is added or removed, update the "Unreleased" section with a d
 - `ensure_ffmpeg()` installs `ffmpeg-python` automatically when the Python wrapper is missing.
 - `pip_install()` and `pip_uninstall()` helper functions manage package installation and removal.
 - `setup_logging()` in `src/logging_setup.py` configures rotating file logs under `logs/` and provides `get_logger()`.
+- Added `get_logger` usage across modules with informative log messages.
+- `run_app.py` and `build_installer.py` now call `setup_logging()` before other imports so early logging works.
 
 ### Changed
  - Replaced `docs/user_guide.pdf` with a plain-text version. The generator

--- a/build_installer.py
+++ b/build_installer.py
@@ -1,11 +1,17 @@
 """Builds a standalone Whisper Transcriber executable using PyInstaller."""
 
+from src.logging_setup import setup_logging, get_logger
+
+setup_logging()
+logger = get_logger("build_installer")
+
 import os
 import PyInstaller.__main__
 import pip._vendor.certifi
 
 
 def main() -> None:
+    logger.info("Building installer")
     cert_path = pip._vendor.certifi.where()
     PyInstaller.__main__.run(
         [

--- a/src/clip_exporter.py
+++ b/src/clip_exporter.py
@@ -1,10 +1,14 @@
 import ffmpeg
+from logging_setup import get_logger
+
+logger = get_logger(__name__)
 
 class ClipExporter:
     """Export a clipped portion of an audio file using ffmpeg-python."""
 
     def export_clip(self, audio_path: str, start: float, end: float, dest_path: str) -> str:
         """Clip audio between ``start`` and ``end`` seconds and save to ``dest_path``."""
+        logger.info("Exporting clip from %s to %s - %s", audio_path, start, end)
         stream = ffmpeg.input(audio_path, ss=start, to=end)
         stream = stream.output(dest_path)
         stream = stream.overwrite_output()

--- a/src/diarizer.py
+++ b/src/diarizer.py
@@ -1,4 +1,7 @@
 from typing import List, Dict
+from logging_setup import get_logger
+
+logger = get_logger(__name__)
 
 # pyannote.audio is heavy, so we import lazily
 
@@ -12,12 +15,14 @@ class Diarizer:
     def _load_pipeline(self):
         """Load the pyannote pipeline when first needed."""
         if self.pipeline is None:
+            logger.info("Loading diarization pipeline: %s", self.model_name)
             from pyannote.audio import Pipeline
             self.pipeline = Pipeline.from_pretrained(self.model_name)
         return self.pipeline
 
     def assign_speakers(self, audio_path: str, segments: List[Dict]) -> List[Dict]:
         """Return segments with speaker labels filled in."""
+        logger.info("Assigning speakers for %s", audio_path)
         self._load_pipeline()
         diarization = self.pipeline(audio_path)
         # diarization.itertracks(yield_label=True) yields (segment, track, label)

--- a/src/keyword_index.py
+++ b/src/keyword_index.py
@@ -1,5 +1,8 @@
 import json
 from typing import List, Dict
+from logging_setup import get_logger
+
+logger = get_logger(__name__)
 
 
 class KeywordIndex:
@@ -13,35 +16,42 @@ class KeywordIndex:
     def load(self) -> None:
         """Load keywords from disk if the file exists."""
         try:
+            logger.debug("Loading keywords from %s", self.path)
             with open(self.path, "r", encoding="utf-8") as fh:
                 self.keywords = json.load(fh)
         except FileNotFoundError:
+            logger.info("Keyword file not found, starting empty")
             self.keywords = []
 
     def save(self) -> None:
         """Persist the current keywords to disk."""
+        logger.info("Saving keywords to %s", self.path)
         with open(self.path, "w", encoding="utf-8") as fh:
             json.dump(self.keywords, fh, indent=2)
 
     def add_keyword(self, keyword: str) -> None:
         """Add a keyword to the list and save if not already present."""
         if keyword not in self.keywords:
+            logger.info("Adding keyword '%s'", keyword)
             self.keywords.append(keyword)
             self.save()
 
     def remove_keyword(self, keyword: str) -> None:
         """Remove a keyword from the list and save."""
         if keyword in self.keywords:
+            logger.info("Removing keyword '%s'", keyword)
             self.keywords.remove(keyword)
             self.save()
 
     def search(self, segments: List[Dict], query: str) -> List[Dict]:
         """Return transcript segments containing the given text query."""
+        logger.debug("Searching for '%s'", query)
         query_lc = query.lower()
         return [seg for seg in segments if query_lc in seg.get("text", "").lower()]
 
     def find_all_editorial(self, segments: List[Dict]) -> List[Dict]:
         """Return segments that contain any stored keyword."""
+        logger.debug("Finding editorial content using %d keywords", len(self.keywords))
         keywords_lc = [k.lower() for k in self.keywords]
         results = []
         for seg in segments:

--- a/src/run_app.py
+++ b/src/run_app.py
@@ -1,3 +1,8 @@
+from logging_setup import setup_logging, get_logger
+
+setup_logging()
+logger = get_logger(__name__)
+
 from bootstrapper import ensure_pyside6
 
 ensure_pyside6()
@@ -8,6 +13,7 @@ from bootstrapper import Bootstrapper
 
 
 def main() -> None:
+    logger.info("Starting application")
     app = QtWidgets.QApplication([])
 
     bootstrapper = Bootstrapper()
@@ -24,6 +30,7 @@ def main() -> None:
     bootstrapper.start()
     progress.exec()
 
+    logger.info("Initializing main window")
     window = MainWindow()
     window.show()
     app.exec()

--- a/src/settings.py
+++ b/src/settings.py
@@ -11,6 +11,9 @@ Usage:
 import json
 import os
 from typing import Dict
+from logging_setup import get_logger
+
+logger = get_logger(__name__)
 
 
 class Settings:
@@ -28,16 +31,19 @@ class Settings:
     def load(self) -> None:
         """Load settings from disk if available, else defaults."""
         try:
+            logger.debug("Loading settings from %s", self.path)
             with open(self.path, "r", encoding="utf-8") as fh:
                 data = json.load(fh)
             self.ui = data.get("ui", {})
             self.keyword_path = data.get("keyword_path", self.keyword_path)
         except FileNotFoundError:
+            logger.info("Settings file not found, using defaults")
             # defaults already set in __init__
             self.ui = {}
 
     def save(self) -> None:
         """Persist current settings to disk."""
+        logger.info("Saving settings to %s", self.path)
         os.makedirs(os.path.dirname(self.path), exist_ok=True)
         with open(self.path, "w", encoding="utf-8") as fh:
             json.dump({"ui": self.ui, "keyword_path": self.keyword_path}, fh, indent=2)

--- a/src/transcribe_worker.py
+++ b/src/transcribe_worker.py
@@ -1,14 +1,19 @@
 from whispercpp import Whisper
+from logging_setup import get_logger
+
+logger = get_logger(__name__)
 
 class TranscribeWorker:
     """Loads a Whisper model and transcribes audio files."""
 
     def __init__(self, model_path: str = "large"):
         self.model_path = model_path
+        logger.info("Loading Whisper model: %s", model_path)
         self.model = Whisper(model_path)
 
     def transcribe(self, audio_path: str):
         """Transcribe the given audio file and return segments."""
+        logger.info("Transcribing %s", audio_path)
         # request timestamps from the Whisper model
         result = self.model.transcribe(audio_path)
         segments = []

--- a/src/transcript_aggregator.py
+++ b/src/transcript_aggregator.py
@@ -1,4 +1,7 @@
 from typing import List, Dict
+from logging_setup import get_logger
+
+logger = get_logger(__name__)
 
 class TranscriptAggregator:
     """Collects transcript segments from multiple audio files."""
@@ -11,6 +14,7 @@ class TranscriptAggregator:
 
         Each segment will be copied and annotated with the source filename.
         """
+        logger.info("Adding %d segments from %s", len(segments), audio_file)
         for seg in segments:
             entry = seg.copy()
             entry["file"] = audio_file
@@ -22,6 +26,7 @@ class TranscriptAggregator:
 
     def rename_speaker(self, old_name: str, new_name: str) -> None:
         """Rename a speaker in all stored segments."""
+        logger.info("Renaming speaker %s to %s", old_name, new_name)
         for seg in self._segments:
             if seg.get("speaker") == old_name:
                 seg["speaker"] = new_name

--- a/src/transcript_exporter.py
+++ b/src/transcript_exporter.py
@@ -4,16 +4,21 @@ from __future__ import annotations
 
 import json
 from typing import List, Dict
+from logging_setup import get_logger
+
+logger = get_logger(__name__)
 
 
 def export_txt(segments: List[Dict]) -> str:
     """Return the transcript as plain text with each segment on a new line."""
+    logger.info("Exporting %d segments as TXT", len(segments))
     lines = [seg.get("text", "") for seg in segments]
     return "\n".join(lines)
 
 
 def export_json(segments: List[Dict]) -> str:
     """Return the transcript segments serialized as formatted JSON."""
+    logger.info("Exporting %d segments as JSON", len(segments))
     return json.dumps(segments, indent=2, ensure_ascii=False)
 
 
@@ -28,6 +33,7 @@ def _format_timestamp(seconds: float) -> str:
 
 def export_srt(segments: List[Dict]) -> str:
     """Return the transcript in SubRip (SRT) subtitle format."""
+    logger.info("Exporting %d segments as SRT", len(segments))
     lines: List[str] = []
     for idx, seg in enumerate(segments, 1):
         start = _format_timestamp(float(seg.get("start", 0.0)))

--- a/src/uninstaller.py
+++ b/src/uninstaller.py
@@ -5,18 +5,24 @@ from __future__ import annotations
 import os
 import sys
 import subprocess
+from logging_setup import get_logger
+
+logger = get_logger(__name__)
 
 
 def pip_uninstall(package: str) -> int:
     """Uninstall *package* using pip via a subprocess."""
+    logger.info("Uninstalling package %s", package)
     result = subprocess.run(
         [sys.executable, "-m", "pip", "uninstall", "-y", package]
     )
+    logger.debug("pip uninstall return code: %s", result.returncode)
     return result.returncode
 
 
 def uninstall_packages(requirements_path: str) -> None:
     """Read ``requirements_path`` and uninstall each package listed."""
+    logger.info("Uninstalling packages listed in %s", requirements_path)
     with open(requirements_path, 'r', encoding='utf-8') as fh:
         packages = [line.strip() for line in fh if line.strip() and not line.startswith('#')]
 


### PR DESCRIPTION
## Summary
- set up logging in `run_app` and `build_installer` before other imports
- use `get_logger` throughout modules for informative messages
- log package installs, file actions, and settings persistence
- document logging additions in the changelog

## Testing
- `pytest -q`