### PR TITLE
Improve build logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ Whenever a feature is added or removed, update the "Unreleased" section with a d
   locate its certificates at runtime.
 - Removed `--hidden-import` options for pip's internal commands and
   `pip._vendor.distlib` from the build script.
+- `build_installer.py` now invokes `setup_logging()` in `main()` and logs the
+  certificate path, output directory and completion status of the PyInstaller
+  run.
 
 ## [0.1.0] – YYYY-MM-DD
 ### Added

--- a/build_installer.py
+++ b/build_installer.py
@@ -2,7 +2,6 @@
 
 from src.logging_setup import setup_logging, get_logger
 
-setup_logging()
 logger = get_logger("build_installer")
 
 import os
@@ -11,8 +10,16 @@ import pip._vendor.certifi
 
 
 def main() -> None:
-    logger.info("Building installer")
+    """Run PyInstaller to build the executable."""
+    setup_logging()
+
+    logger.info("Starting PyInstaller build")
     cert_path = pip._vendor.certifi.where()
+    out_dir = "dist"
+    logger.info("Resolved certificate path: %s", cert_path)
+    logger.info("Output directory: %s", out_dir)
+
+    logger.info("Invoking PyInstaller")
     PyInstaller.__main__.run(
         [
             "src/run_app.py",
@@ -25,9 +32,10 @@ def main() -> None:
             "--hidden-import=pip._vendor.certifi",
             f"--add-data={cert_path}{os.pathsep}pip/_vendor/certifi",
             "--distpath",
-            "dist",
+            out_dir,
         ]
     )
+    logger.info("PyInstaller build completed")
 
 
 if __name__ == "__main__":  # pragma: no cover - not tested

--- a/tests/test_build_installer.py
+++ b/tests/test_build_installer.py
@@ -1,0 +1,64 @@
+import os
+import sys
+import types
+import importlib
+import importlib.util
+from pathlib import Path
+
+# Add repo root and src directory to path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+
+def test_build_installer_logs_created(monkeypatch):
+    # stub PyInstaller
+    run_args = []
+    pyinstaller_main = types.ModuleType('PyInstaller.__main__')
+    def fake_run(args):
+        run_args.append(args)
+    pyinstaller_main.run = fake_run
+    pyinstaller = types.ModuleType('PyInstaller')
+    pyinstaller.__main__ = pyinstaller_main
+    monkeypatch.setitem(sys.modules, 'PyInstaller', pyinstaller)
+    monkeypatch.setitem(sys.modules, 'PyInstaller.__main__', pyinstaller_main)
+
+    # load real logging_setup without importing full src package
+    spec = importlib.util.spec_from_file_location(
+        'src.logging_setup',
+        os.path.join(os.path.dirname(__file__), '..', 'src', 'logging_setup.py'),
+    )
+    logging_setup = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(logging_setup)
+    stub_src = types.ModuleType('src')
+    stub_src.logging_setup = logging_setup
+    monkeypatch.setitem(sys.modules, 'src', stub_src)
+    monkeypatch.setitem(sys.modules, 'src.logging_setup', logging_setup)
+
+    # stub ffmpeg to satisfy src package imports
+    fake_ffmpeg = types.ModuleType('ffmpeg')
+    monkeypatch.setitem(sys.modules, 'ffmpeg', fake_ffmpeg)
+
+    # stub certifi
+    certifi = types.ModuleType('pip._vendor.certifi')
+    certifi.where = lambda: '/fake/cert.pem'
+    monkeypatch.setitem(sys.modules, 'pip._vendor.certifi', certifi)
+    pip_mod = types.ModuleType('pip')
+    pip_mod._vendor = types.ModuleType('pip._vendor')
+    pip_mod._vendor.certifi = certifi
+    monkeypatch.setitem(sys.modules, 'pip', pip_mod)
+    monkeypatch.setitem(sys.modules, 'pip._vendor', pip_mod._vendor)
+
+    # ensure log file removed
+    log_file = Path(__file__).resolve().parent.parent / 'logs' / 'installer_build.log'
+    if log_file.exists():
+        log_file.unlink()
+
+    build_installer = importlib.import_module('build_installer')
+    build_installer = importlib.reload(build_installer)
+
+    build_installer.main()
+
+    assert run_args, 'PyInstaller.run was not called'
+    assert log_file.exists()
+    assert 'Starting PyInstaller build' in log_file.read_text()
+


### PR DESCRIPTION
## Summary
- add runtime logging to `build_installer`
- log certificate location and output directory
- test log file creation when running installer build

## Testing
- `pytest -q`