### PR TITLE
Add logging documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Whenever a feature is added or removed, update the "Unreleased" section with a d
 - `setup_logging()` in `src/logging_setup.py` configures rotating file logs under `logs/` and provides `get_logger()`.
 - Added `get_logger` usage across modules with informative log messages.
 - `run_app.py` and `build_installer.py` now call `setup_logging()` before other imports so early logging works.
+- Log files are generated per module in `logs/`, such as `app.log` for the main application and `installer_build.log` for the installer builder.
 
 ### Changed
  - Replaced `docs/user_guide.pdf` with a plain-text version. The generator

--- a/README.md
+++ b/README.md
@@ -123,11 +123,15 @@ The resulting executable will be placed in the `dist/` directory. The
 `installer/whisper_transcriber.nsi` script can then be adapted to wrap this
 binary in an NSIS installer.
 
-## Log Files
+## Logging
 
-Application logs are written to the `logs/` directory at the repository root.
-`app.log` stores general runtime messages and `installer_build.log` captures
-output from `build_installer.py`.
+All logs are stored in the `logs/` directory in the project root. Each major
+component writes to its own file. The main application logs to `app.log` and the
+installer builder logs to `installer_build.log`. Modules that call
+`get_logger()` create additional files under `logs/`.
+
+The default log level is `INFO`. Edit the `level` fields in
+[`src/logging_setup.py`](src/logging_setup.py) to change verbosity.
 
 ## Contributor Resources
 


### PR DESCRIPTION
## Notes
- Expanded README with a new **Logging** section describing where log files are stored, the separate files per component and how to change log levels.
- Updated CHANGELOG entry to document per-module log files.

## Testing
- `pytest -q`