### PR TITLE
Fix build_installer import path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Whenever a feature is added or removed, update the "Unreleased" section with a d
 - `build_installer.py` now invokes `setup_logging()` in `main()` and logs the
   certificate path, output directory and completion status of the PyInstaller
   run.
+- `build_installer.py` now prepends the repository's `src` directory to `sys.path` so `src.logging_setup` imports reliably.
 
 ## [0.1.0] – YYYY-MM-DD
 ### Added

--- a/build_installer.py
+++ b/build_installer.py
@@ -1,4 +1,6 @@
 """Builds a standalone Whisper Transcriber executable using PyInstaller."""
+import os, sys
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "src"))
 
 from src.logging_setup import setup_logging, get_logger
 


### PR DESCRIPTION
## Notes
- none

## Summary
- ensure `src` is on `sys.path` at the start of `build_installer.py`
- document the fix in the changelog

## Testing
- `pytest -q`