### PR TITLE
Refactor src package exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,12 @@ Whenever a feature is added or removed, update the "Unreleased" section with a d
   `logs/installer_build.log`. It also notes that log files rotate and reside in
   the `logs/` directory.
 
+### Removed
+- **BREAKING**: `src.__init__` no longer imports `TranscriptAggregator`,
+  `KeywordIndex`, `ClipExporter`, `transcript_exporter`, `Settings`, or
+  `MainWindow` eagerly. Import these objects from their specific modules instead
+  of `src`.
+
 ## [0.1.0] – YYYY-MM-DD
 ### Added
 - Initial changelog with sections for future releases.

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,19 +1,36 @@
-"""PodcastAssistant public interface."""
+"""PodcastAssistant public interface.
 
-from .transcript_aggregator import TranscriptAggregator
-from .keyword_index import KeywordIndex
-from .clip_exporter import ClipExporter
-from .transcript_exporter import export_txt, export_json, export_srt
-from .settings import Settings
-from .main_window import MainWindow
+Only lazily exposes the underlying modules. This avoids importing heavy
+dependencies until explicitly requested.
+"""
+
+from __future__ import annotations
+
+import importlib
+import types
 
 __all__ = [
-    "TranscriptAggregator",
-    "KeywordIndex",
-    "ClipExporter",
-    "export_txt",
-    "export_json",
-    "export_srt",
-    "Settings",
-    "MainWindow",
+    "transcript_aggregator",
+    "keyword_index",
+    "clip_exporter",
+    "transcript_exporter",
+    "settings",
+    "main_window",
 ]
+
+
+def __getattr__(name: str) -> types.ModuleType:
+    """Dynamically import submodules when accessed.
+
+    This function implements PEP 562 module ``__getattr__`` so accessing an
+    attribute like ``src.transcript_aggregator`` triggers an import of the
+    corresponding submodule.
+    """
+    if name in __all__:
+        return importlib.import_module(f".{name}", __name__)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:
+    """Return available attributes for ``dir()`` calls."""
+    return sorted(list(globals().keys()) + __all__)


### PR DESCRIPTION
## Summary
- lazily import modules via `__getattr__` in `src.__init__`
- document the breaking change in the changelog

## Testing
- `pytest -q`