### PR TITLE
Update bootstrapper for PyInstaller requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,9 +37,11 @@ Whenever a feature is added or removed, update the "Unreleased" section with a d
     `logs/app.log` except `build_installer.py`, which uses
     `logs/installer_build.log`. It also notes that log files rotate and reside in
     the `logs/` directory.
- - `run_app.py` now imports `MainWindow` only after the bootstrapper finishes
+- `run_app.py` now imports `MainWindow` only after the bootstrapper finishes
    installing packages. This prevents `ModuleNotFoundError` for modules like
    `whispercpp` when launching the packaged executable.
+- `Bootstrapper.__init__` now checks `sys.frozen` and reads `requirements.txt`
+  from the executable's directory when running as a PyInstaller bundle.
 
 ### Removed
 - **BREAKING**: `src.__init__` no longer imports `TranscriptAggregator`,

--- a/README.md
+++ b/README.md
@@ -119,6 +119,11 @@ python build_installer.py
 The build process bundles pip's CA certificates so that pip can install
 missing packages at runtime.
 
+When running the bundled executable, the bootstrapper checks ``sys.frozen``. If
+set, it reads ``requirements.txt`` from the same directory as
+``sys.executable``. When running from source, it falls back to the repository's
+``requirements.txt``.
+
 The resulting executable will be placed in the `dist/` directory. The
 `installer/whisper_transcriber.nsi` script can then be adapted to wrap this
 binary in an NSIS installer.

--- a/src/bootstrapper.py
+++ b/src/bootstrapper.py
@@ -56,7 +56,17 @@ class Bootstrapper(QtCore.QThread):
     def __init__(self, requirements_path: str | None = None, parent=None) -> None:
         super().__init__(parent)
         if requirements_path is None:
-            requirements_path = os.path.join(os.path.dirname(__file__), '..', 'requirements.txt')
+            if getattr(sys, 'frozen', False):
+                requirements_path = os.path.join(
+                    os.path.dirname(sys.executable),
+                    'requirements.txt',
+                )
+            else:
+                requirements_path = os.path.join(
+                    os.path.dirname(__file__),
+                    '..',
+                    'requirements.txt',
+                )
         self.requirements_path = os.path.abspath(requirements_path)
 
     def _read_packages(self) -> list[str]:


### PR DESCRIPTION
## Summary
- set `requirements_path` from the executable directory when running as a PyInstaller bundle
- test new bootstrapper behaviour when `sys.frozen` is set
- document frozen requirements path behaviour
- note bootstrapper change in the changelog

## Testing
- `pytest -q`