### PR TITLE
Improve package detection in bootstrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,9 @@ Whenever a feature is added or removed, update the "Unreleased" section with a d
    `whispercpp` when launching the packaged executable.
 - `Bootstrapper.__init__` now checks `sys.frozen` and reads `requirements.txt`
   from the executable's directory when running as a PyInstaller bundle.
+- `Bootstrapper._missing_packages` now imports each module with
+  `importlib.import_module` and marks packages missing when an `ImportError`
+  occurs. Tests patch `importlib.import_module` accordingly.
 
 ### Removed
 - **BREAKING**: `src.__init__` no longer imports `TranscriptAggregator`,

--- a/src/bootstrapper.py
+++ b/src/bootstrapper.py
@@ -78,7 +78,9 @@ class Bootstrapper(QtCore.QThread):
         missing = []
         for pkg in packages:
             name = pkg.split('==')[0]
-            if importlib.util.find_spec(name) is None:
+            try:
+                importlib.import_module(name)
+            except ImportError:
                 missing.append(pkg)
         return missing
 


### PR DESCRIPTION
## Summary
- detect missing packages by attempting to import them
- patch bootstrapper tests to use the new detection logic
- note new behavior in the changelog

## Testing
- `pytest -q`