### PR TITLE
Update docs for bootstrapper and installer packaging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,8 @@ Whenever a feature is added or removed, update the "Unreleased" section with a d
 - Log files are generated per module in `logs/`, such as `app.log` for the main application and `installer_build.log` for the installer builder.
 - Added a `logs/` directory with a `.gitkeep` file so the log folder is tracked in version control.
 - `.gitignore` now excludes log files under `logs/*.log`.
-- `build_installer.py` now bundles `requirements.txt` via PyInstaller's
-  `--add-data` option so the packaged application can access its dependency list.
+- `build_installer.py` now packages `requirements.txt` with the executable using
+  PyInstaller's `--add-data` option so the installer includes the dependency list.
 
 ### Changed
  - Replaced `docs/user_guide.pdf` with a plain-text version. The generator

--- a/README.md
+++ b/README.md
@@ -117,12 +117,12 @@ python build_installer.py
 ```
 
 The build process bundles pip's CA certificates so that pip can install
-missing packages at runtime.
+missing packages at runtime. It also packages ``requirements.txt`` next to the
+executable so the bootstrapper can read it when frozen.
 
-When running the bundled executable, the bootstrapper checks ``sys.frozen``. If
-set, it reads ``requirements.txt`` from the same directory as
-``sys.executable``. When running from source, it falls back to the repository's
-``requirements.txt``.
+When running the bundled executable, the bootstrapper checks ``sys.frozen`` and
+loads this bundled ``requirements.txt`` from the executable's directory. When
+running from source, it falls back to the repository's ``requirements.txt``.
 
 The resulting executable will be placed in the `dist/` directory. The
 `installer/whisper_transcriber.nsi` script can then be adapted to wrap this


### PR DESCRIPTION
## Summary
- document bundling `requirements.txt` in the installer
- explain how the bootstrapper finds it when frozen
- clarify improved package detection in changelog

## Testing
- `pytest -q`
