### PR TITLE
Fix packaging to include whispercpp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,9 @@ Whenever a feature is added or removed, update the "Unreleased" section with a d
 - `Bootstrapper._missing_packages` now imports each module with
   `importlib.import_module` and marks packages missing when an `ImportError`
   occurs. Tests patch `importlib.import_module` accordingly.
+- `build_installer.py` now passes `--collect-all=whispercpp` and
+  `--hidden-import=whispercpp` to PyInstaller so the packaged executable
+  includes WhisperCPP resources.
 
 ### Removed
 - **BREAKING**: `src.__init__` no longer imports `TranscriptAggregator`,

--- a/README.md
+++ b/README.md
@@ -119,6 +119,8 @@ python build_installer.py
 The build process bundles pip's CA certificates so that pip can install
 missing packages at runtime. It also packages ``requirements.txt`` next to the
 executable so the bootstrapper can read it when frozen.
+It further collects all ``whispercpp`` resources so the embedded
+transcription engine works out of the box.
 
 When running the bundled executable, the bootstrapper checks ``sys.frozen`` and
 loads this bundled ``requirements.txt`` from the executable's directory. When

--- a/build_installer.py
+++ b/build_installer.py
@@ -32,6 +32,8 @@ def main() -> None:
             "--windowed",
             "--noconfirm",
             "--hidden-import=pip._vendor.certifi",
+            "--collect-all=whispercpp",
+            "--hidden-import=whispercpp",
             f"--add-data={cert_path}{os.pathsep}pip/_vendor/certifi",
             f"--add-data=requirements.txt{os.pathsep}.",
             "--distpath",

--- a/tests/test_build_installer.py
+++ b/tests/test_build_installer.py
@@ -60,6 +60,7 @@ def test_build_installer_logs_created(monkeypatch):
 
     assert run_args, 'PyInstaller.run was not called'
     assert f"--add-data=requirements.txt{os.pathsep}." in run_args[0]
+    assert "--collect-all=whispercpp" in run_args[0]
     assert log_file.exists()
     assert 'Starting PyInstaller build' in log_file.read_text()
 


### PR DESCRIPTION
## Summary
- ensure `whispercpp` files are collected by PyInstaller
- test that PyInstaller gets `--collect-all=whispercpp`
- document the packaging fix
- mention resource collection in README

## Testing
- `pytest -q`