### PR TITLE
Add bundled uninstaller support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Whenever a feature is added or removed, update the "Unreleased" section with a d
 - `.gitignore` now excludes log files under `logs/*.log`.
 - `build_installer.py` now packages `requirements.txt` with the executable using
   PyInstaller's `--add-data` option so the installer includes the dependency list.
+- `build_installer.py` now bundles `src/uninstaller.py` with the executable so
+  the uninstaller can run from the packaged application.
+- `run_app.py` exits early when invoked with `uninstaller.py` and calls
+  `uninstall_packages()` using the bundled `requirements.txt` path.
 
 ### Changed
  - Replaced `docs/user_guide.pdf` with a plain-text version. The generator

--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@
   - Full transcript → TXT, JSON, SRT
 - Highlighted segment → same text formats plus clipped audio (FFmpeg).
 - Entirely offline / internal use; no data leaves the machine.
-- Uninstallation cleans up any dependencies installed by the bootstrapper.
+- Uninstallation cleans up any dependencies installed by the bootstrapper. Run
+  `WhisperTranscriber.exe uninstaller.py` (or `python src/uninstaller.py` when
+  running from source) to remove them.
 
 ## 2 — Technology Stack
 

--- a/build_installer.py
+++ b/build_installer.py
@@ -36,6 +36,7 @@ def main() -> None:
             "--hidden-import=whispercpp",
             f"--add-data={cert_path}{os.pathsep}pip/_vendor/certifi",
             f"--add-data=requirements.txt{os.pathsep}.",
+            f"--add-data=src/uninstaller.py{os.pathsep}.",
             "--distpath",
             out_dir,
         ]

--- a/src/run_app.py
+++ b/src/run_app.py
@@ -1,4 +1,6 @@
 from logging_setup import setup_logging, get_logger
+import os
+import sys
 
 setup_logging()
 logger = get_logger(__name__)
@@ -12,6 +14,15 @@ from bootstrapper import Bootstrapper
 
 
 def main() -> None:
+    if len(sys.argv) > 1 and sys.argv[1].endswith("uninstaller.py"):
+        if getattr(sys, "frozen", False):
+            req_path = os.path.join(os.path.dirname(sys.executable), "requirements.txt")
+        else:
+            req_path = os.path.join(os.path.dirname(__file__), "..", "requirements.txt")
+        import uninstaller
+        uninstaller.uninstall_packages(req_path)
+        return
+
     logger.info("Starting application")
     app = QtWidgets.QApplication([])
 

--- a/tests/test_build_installer.py
+++ b/tests/test_build_installer.py
@@ -60,6 +60,7 @@ def test_build_installer_logs_created(monkeypatch):
 
     assert run_args, 'PyInstaller.run was not called'
     assert f"--add-data=requirements.txt{os.pathsep}." in run_args[0]
+    assert f"--add-data=src/uninstaller.py{os.pathsep}." in run_args[0]
     assert "--collect-all=whispercpp" in run_args[0]
     assert log_file.exists()
     assert 'Starting PyInstaller build' in log_file.read_text()

--- a/tests/test_run_app.py
+++ b/tests/test_run_app.py
@@ -1,0 +1,38 @@
+import os
+import sys
+import types
+import importlib
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+
+def test_run_app_invokes_uninstaller(monkeypatch):
+    runs = []
+
+    boot = types.ModuleType('bootstrapper')
+    boot.ensure_pyside6 = lambda: None
+    boot.Bootstrapper = lambda *a, **k: None
+    monkeypatch.setitem(sys.modules, 'bootstrapper', boot)
+
+    qtwidgets = types.ModuleType('PySide6.QtWidgets')
+    pyside6 = types.ModuleType('PySide6')
+    pyside6.QtWidgets = qtwidgets
+    monkeypatch.setitem(sys.modules, 'PySide6', pyside6)
+    monkeypatch.setitem(sys.modules, 'PySide6.QtWidgets', qtwidgets)
+
+    un = types.ModuleType('uninstaller')
+    def fake_uninstall(path):
+        runs.append(path)
+    un.uninstall_packages = fake_uninstall
+    monkeypatch.setitem(sys.modules, 'uninstaller', un)
+
+    monkeypatch.setattr(sys, 'argv', ['run_app.py', 'uninstaller.py'])
+
+    mod = importlib.import_module('run_app')
+    mod = importlib.reload(mod)
+
+    mod.main()
+
+    expected = os.path.join(os.path.dirname(mod.__file__), '..', 'requirements.txt')
+    assert runs == [expected]


### PR DESCRIPTION
## Summary
- bundle `src/uninstaller.py` when building the executable
- exit early in `run_app.main()` when called with `uninstaller.py`
- expect new `--add-data` option in build-installer test
- test that `run_app` invokes the uninstaller
- document uninstaller usage and changelog entry

## Testing
- `pytest -q`