### PR TITLE
Ignore PyInstaller spec files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ build/
 .mypy_cache/
 out.json
 logs/*.log
+*.spec

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Whenever a feature is added or removed, update the "Unreleased" section with a d
   the uninstaller can run from the packaged application.
 - `run_app.py` exits early when invoked with `uninstaller.py` and calls
   `uninstall_packages()` using the bundled `requirements.txt` path.
+- `.gitignore` now excludes PyInstaller-generated `*.spec` files.
 
 ### Changed
  - Replaced `docs/user_guide.pdf` with a plain-text version. The generator


### PR DESCRIPTION
## Summary
- ignore `*.spec` build artifacts generated by PyInstaller
- document this ignore rule in the changelog

## Testing
- `git status --short`