### PR TITLE
Collect whispercpp binaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,8 @@ Whenever a feature is added or removed, update the "Unreleased" section with a d
 - `build_installer.py` now passes `--collect-all=whispercpp` and
   `--hidden-import=whispercpp` to PyInstaller so the packaged executable
   includes WhisperCPP resources.
+- `build_installer.py` now passes `--collect-binaries=whispercpp` so the
+  transcription engine's binary library is bundled.
 
 ### Removed
 - **BREAKING**: `src.__init__` no longer imports `TranscriptAggregator`,

--- a/README.md
+++ b/README.md
@@ -122,7 +122,9 @@ The build process bundles pip's CA certificates so that pip can install
 missing packages at runtime. It also packages ``requirements.txt`` next to the
 executable so the bootstrapper can read it when frozen.
 It further collects all ``whispercpp`` resources so the embedded
-transcription engine works out of the box.
+transcription engine works out of the box. The script additionally passes
+``--collect-binaries=whispercpp`` so the compiled library for the
+transcription engine is included.
 
 When running the bundled executable, the bootstrapper checks ``sys.frozen`` and
 loads this bundled ``requirements.txt`` from the executable's directory. When

--- a/build_installer.py
+++ b/build_installer.py
@@ -33,6 +33,7 @@ def main() -> None:
             "--noconfirm",
             "--hidden-import=pip._vendor.certifi",
             "--collect-all=whispercpp",
+            "--collect-binaries=whispercpp",
             "--hidden-import=whispercpp",
             f"--add-data={cert_path}{os.pathsep}pip/_vendor/certifi",
             f"--add-data=requirements.txt{os.pathsep}.",

--- a/tests/test_build_installer.py
+++ b/tests/test_build_installer.py
@@ -62,6 +62,7 @@ def test_build_installer_logs_created(monkeypatch):
     assert f"--add-data=requirements.txt{os.pathsep}." in run_args[0]
     assert f"--add-data=src/uninstaller.py{os.pathsep}." in run_args[0]
     assert "--collect-all=whispercpp" in run_args[0]
+    assert "--collect-binaries=whispercpp" in run_args[0]
     assert log_file.exists()
     assert 'Starting PyInstaller build' in log_file.read_text()
 


### PR DESCRIPTION
## Summary
- include `--collect-binaries=whispercpp` when building the PyInstaller bundle
- document whispercpp binary collection in the build instructions
- test for the new PyInstaller argument
- mention whispercpp binaries in the changelog

## Testing
- `pytest -q`