### PR TITLE
Add PyInstaller hook for whispercpp dynamic libs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ Whenever a feature is added or removed, update the "Unreleased" section with a d
 - `run_app.py` exits early when invoked with `uninstaller.py` and calls
   `uninstall_packages()` using the bundled `requirements.txt` path.
 - `.gitignore` now excludes PyInstaller-generated `*.spec` files.
+- PyInstaller build now loads `pyinstaller_hooks/hook-whispercpp.py` via
+  `--additional-hooks-dir` so WhisperCPP's dynamic libraries bundle correctly.
 
 ### Changed
  - Replaced `docs/user_guide.pdf` with a plain-text version. The generator

--- a/README.md
+++ b/README.md
@@ -124,7 +124,10 @@ executable so the bootstrapper can read it when frozen.
 It further collects all ``whispercpp`` resources so the embedded
 transcription engine works out of the box. The script additionally passes
 ``--collect-binaries=whispercpp`` so the compiled library for the
-transcription engine is included.
+transcription engine is included. A custom hook under ``pyinstaller_hooks/``
+adds ``hook-whispercpp.py`` which collects dynamic libraries for
+``whispercpp``. The build script passes
+``--additional-hooks-dir=pyinstaller_hooks`` so PyInstaller can load this hook.
 
 When running the bundled executable, the bootstrapper checks ``sys.frozen`` and
 loads this bundled ``requirements.txt`` from the executable's directory. When

--- a/build_installer.py
+++ b/build_installer.py
@@ -27,6 +27,7 @@ def main() -> None:
             "src/run_app.py",
             "--paths",
             "src",
+            "--additional-hooks-dir=pyinstaller_hooks",
             "--name=WhisperTranscriber",
             "--onefile",
             "--windowed",

--- a/pyinstaller_hooks/hook-whispercpp.py
+++ b/pyinstaller_hooks/hook-whispercpp.py
@@ -1,0 +1,2 @@
+from PyInstaller.utils.hooks import collect_dynamic_libs
+binaries = collect_dynamic_libs("whispercpp")

--- a/tests/test_build_installer.py
+++ b/tests/test_build_installer.py
@@ -63,6 +63,7 @@ def test_build_installer_logs_created(monkeypatch):
     assert f"--add-data=src/uninstaller.py{os.pathsep}." in run_args[0]
     assert "--collect-all=whispercpp" in run_args[0]
     assert "--collect-binaries=whispercpp" in run_args[0]
+    assert "--additional-hooks-dir=pyinstaller_hooks" in run_args[0]
     assert log_file.exists()
     assert 'Starting PyInstaller build' in log_file.read_text()
 


### PR DESCRIPTION
## Summary
- include custom PyInstaller hook `hook-whispercpp.py`
- run PyInstaller with `--additional-hooks-dir=pyinstaller_hooks`
- verify hook argument in `test_build_installer`
- document hook usage in README
- update changelog

## Testing
- `pytest -q`