### PR TITLE
Handle pip install failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,10 +40,13 @@ Whenever a feature is added or removed, update the "Unreleased" section with a d
   certificate path, output directory and completion status of the PyInstaller
   run.
 - `build_installer.py` now prepends the repository's `src` directory to `sys.path` so `src.logging_setup` imports reliably.
-  - README logging documentation now clarifies that all modules write to
-    `logs/app.log` except `build_installer.py`, which uses
-    `logs/installer_build.log`. It also notes that log files rotate and reside in
-    the `logs/` directory.
+    - README logging documentation now clarifies that all modules write to
+      `logs/app.log` except `build_installer.py`, which uses
+      `logs/installer_build.log`. It also notes that log files rotate and reside in
+      the `logs/` directory.
+- `pip_install()` now raises an exception when pip exits with a non-zero code and
+  `Bootstrapper.run()` aborts installation, logging the error and showing a
+  message box when running under Qt.
 - `run_app.py` now imports `MainWindow` only after the bootstrapper finishes
    installing packages. This prevents `ModuleNotFoundError` for modules like
    `whispercpp` when launching the packaged executable.

--- a/docs/user_guide.txt
+++ b/docs/user_guide.txt
@@ -4,6 +4,8 @@ Installation:
 1. Install Python. FFmpeg will be installed automatically by the bootstrapper.
 2. Run 'python build_installer.py' to create the executable.
 3. Launch the installer from 'dist/'.
+4. If any dependency fails to install, the bootstrapper stops and shows an error
+   message so you can check the logs.
 
 Basic Usage:
 1. Drag audio files into the file list in order.


### PR DESCRIPTION
## Summary
- raise `RuntimeError` from `pip_install` when pip returns a non-zero status
- abort package installation in `Bootstrapper.run` and show a message box if Qt is available
- test the bootstrapper's behaviour when an installation fails
- document bootstrapper failure handling in the user guide
- describe this change in the changelog

## Testing
- `pytest -q`