### PR TITLE
Document Python prerequisites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Whenever a feature is added or removed, update the "Unreleased" section with a d
 - `.gitignore` now excludes PyInstaller-generated `*.spec` files.
 - PyInstaller build now loads `pyinstaller_hooks/hook-whispercpp.py` via
   `--additional-hooks-dir` so WhisperCPP's dynamic libraries bundle correctly.
+- Documented Python version requirements in README and user guide; note that newer versions may lack `whispercpp` wheels.
 
 ### Changed
  - Replaced `docs/user_guide.pdf` with a plain-text version. The generator

--- a/README.md
+++ b/README.md
@@ -99,13 +99,17 @@ application is launched.
 - Source repository with tests, prompts, and README
 - [User Guide](docs/user_guide.txt) with installation and usage instructions
 
+## Prerequisites
+
+- Python 3.10 or 3.11. Newer versions may not have wheels for `whispercpp`.
+
 That’s the entire plan—feature set, tech choices, modules, and deliverables—without any timelines.
 
 ## Building the Installer
 
 ### Prerequisites
 
-- Python with all packages from `requirements.txt`
+- Python 3.10 or 3.11 with all packages from `requirements.txt` (newer versions may not have `whispercpp` wheels)
 - `pyinstaller` available on your PATH (`pip install pyinstaller`)
 - (Optional) [NSIS](https://nsis.sourceforge.io/) for creating the final
   Windows installer.

--- a/docs/user_guide.txt
+++ b/docs/user_guide.txt
@@ -1,5 +1,8 @@
 Whisper Transcriber User Guide
 
+Prerequisites:
+- Python 3.10 or 3.11. Newer versions may not have wheels for `whispercpp`.
+
 Installation:
 1. Install Python. FFmpeg will be installed automatically by the bootstrapper.
 2. Run 'python build_installer.py' to create the executable.


### PR DESCRIPTION
## Summary
- document Python 3.10/3.11 requirement in README
- add prerequisites section to the user guide
- note the version docs in CHANGELOG

## Testing
- `pytest -q`