### PR TITLE
Install dependencies at build time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,12 +14,6 @@ Whenever a feature is added or removed, update the "Unreleased" section with a d
 - Log files are generated per module in `logs/`, such as `app.log` for the main application and `installer_build.log` for the installer builder.
 - Added a `logs/` directory with a `.gitkeep` file so the log folder is tracked in version control.
 - `.gitignore` now excludes log files under `logs/*.log`.
-- `build_installer.py` now packages `requirements.txt` with the executable using
-  PyInstaller's `--add-data` option so the installer includes the dependency list.
-- `build_installer.py` now bundles `src/uninstaller.py` with the executable so
-  the uninstaller can run from the packaged application.
-- `run_app.py` exits early when invoked with `uninstaller.py` and calls
-  `uninstall_packages()` using the bundled `requirements.txt` path.
 - `.gitignore` now excludes PyInstaller-generated `*.spec` files.
 - PyInstaller build now loads `pyinstaller_hooks/hook-whispercpp.py` via
   `--additional-hooks-dir` so WhisperCPP's dynamic libraries bundle correctly.
@@ -50,7 +44,7 @@ Whenever a feature is added or removed, update the "Unreleased" section with a d
   message box when running under Qt.
 - `run_app.py` now imports `MainWindow` only after the bootstrapper finishes
    installing packages. This prevents `ModuleNotFoundError` for modules like
-   `whispercpp` when launching the packaged executable.
+  `whispercpp` when launching the packaged executable.
 - `Bootstrapper.__init__` now checks `sys.frozen` and reads `requirements.txt`
   from the executable's directory when running as a PyInstaller bundle.
 - `Bootstrapper._missing_packages` now imports each module with
@@ -61,6 +55,9 @@ Whenever a feature is added or removed, update the "Unreleased" section with a d
   includes WhisperCPP resources.
 - `build_installer.py` now passes `--collect-binaries=whispercpp` so the
   transcription engine's binary library is bundled.
+- Dependencies are now installed before building and bundled inside the
+  executable. `build_installer.py` no longer copies `requirements.txt` or
+  `src/uninstaller.py` into the PyInstaller bundle.
 
 ### Removed
 - **BREAKING**: `src.__init__` no longer imports `TranscriptAggregator`,

--- a/README.md
+++ b/README.md
@@ -102,10 +102,16 @@ That’s the entire plan—feature set, tech choices, modules, and deliverables�
 
 ### Prerequisites
 
-- Python 3.10 or 3.11 with all packages from `requirements.txt` (newer versions may not have `whispercpp` wheels)
+- Python 3.10 or 3.11 with all packages from `requirements.txt` (newer versions
+  may not have `whispercpp` wheels)
 - `pyinstaller` available on your PATH (`pip install pyinstaller`)
 - (Optional) [NSIS](https://nsis.sourceforge.io/) for creating the final
   Windows installer.
+- Install the project dependencies before building:
+
+  ```bash
+  pip install -r requirements.txt
+  ```
 
 ### Invocation
 
@@ -115,11 +121,10 @@ Run the helper script which invokes PyInstaller:
 python build_installer.py
 ```
 
-The build process bundles pip's CA certificates so that pip can install
-missing packages at runtime. It also packages ``requirements.txt`` next to the
-executable so the application can read it when frozen.
-It further collects all ``whispercpp`` resources so the embedded
-transcription engine works out of the box. The script additionally passes
+All dependencies must be installed prior to running the build script. PyInstaller
+copies these packages into the executable so everything is available at runtime.
+The process also bundles pip's CA certificates and collects all ``whispercpp``
+resources so the embedded transcription engine works out of the box. The script additionally passes
 ``--collect-binaries=whispercpp`` so the compiled library for the
 transcription engine is included. A custom hook under ``pyinstaller_hooks/``
 adds ``hook-whispercpp.py`` which collects dynamic libraries for

--- a/build_installer.py
+++ b/build_installer.py
@@ -37,8 +37,6 @@ def main() -> None:
             "--collect-binaries=whispercpp",
             "--hidden-import=whispercpp",
             f"--add-data={cert_path}{os.pathsep}pip/_vendor/certifi",
-            f"--add-data=requirements.txt{os.pathsep}.",
-            f"--add-data=src/uninstaller.py{os.pathsep}.",
             "--distpath",
             out_dir,
         ]

--- a/tests/test_build_installer.py
+++ b/tests/test_build_installer.py
@@ -59,8 +59,8 @@ def test_build_installer_logs_created(monkeypatch):
     build_installer.main()
 
     assert run_args, 'PyInstaller.run was not called'
-    assert f"--add-data=requirements.txt{os.pathsep}." in run_args[0]
-    assert f"--add-data=src/uninstaller.py{os.pathsep}." in run_args[0]
+    assert f"--add-data=requirements.txt{os.pathsep}." not in run_args[0]
+    assert f"--add-data=src/uninstaller.py{os.pathsep}." not in run_args[0]
     assert "--collect-all=whispercpp" in run_args[0]
     assert "--collect-binaries=whispercpp" in run_args[0]
     assert "--additional-hooks-dir=pyinstaller_hooks" in run_args[0]


### PR DESCRIPTION
## Summary
- update build_installer.py to stop bundling requirements.txt and the uninstaller
- document that dependencies must be installed before building
- update changelog with new dependency packaging note
- adjust tests for updated build script

## Testing
- `pytest -q`