### PR TITLE
Simplify run_app startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,8 @@ Whenever a feature is added or removed, update the "Unreleased" section with a d
 - Dependencies are now installed before building and bundled inside the
   executable. `build_installer.py` no longer copies `requirements.txt` or
   `src/uninstaller.py` into the PyInstaller bundle.
+- `run_app.py` launches `MainWindow` directly. Startup no longer displays a
+  progress dialog or reads `requirements.txt`.
 
 ### Removed
 - **BREAKING**: `src.__init__` no longer imports `TranscriptAggregator`,

--- a/src/run_app.py
+++ b/src/run_app.py
@@ -21,8 +21,6 @@ def main() -> None:
 
     logger.info("Starting application")
     app = QtWidgets.QApplication([])
-
-    logger.info("Initializing main window")
     window = MainWindow()
     window.show()
     app.exec()

--- a/tests/test_run_app.py
+++ b/tests/test_run_app.py
@@ -2,6 +2,7 @@ import os
 import sys
 import types
 import importlib
+from test_main_window import make_pyside6_stub
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
@@ -10,11 +11,13 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
 def test_run_app_invokes_uninstaller(monkeypatch):
     runs = []
 
-    qtwidgets = types.ModuleType('PySide6.QtWidgets')
-    pyside6 = types.ModuleType('PySide6')
-    pyside6.QtWidgets = qtwidgets
-    monkeypatch.setitem(sys.modules, 'PySide6', pyside6)
-    monkeypatch.setitem(sys.modules, 'PySide6.QtWidgets', qtwidgets)
+    stubs = make_pyside6_stub()
+    for name, module in stubs.items():
+        monkeypatch.setitem(sys.modules, name, module)
+
+    mw = types.ModuleType('main_window')
+    mw.MainWindow = lambda: None
+    monkeypatch.setitem(sys.modules, 'main_window', mw)
 
     un = types.ModuleType('uninstaller')
     def fake_remove(path):
@@ -31,4 +34,40 @@ def test_run_app_invokes_uninstaller(monkeypatch):
 
     expected = os.path.dirname(os.path.dirname(mod.__file__))
     assert runs == [expected]
+
+
+def test_run_app_starts_without_progress_dialog(monkeypatch):
+    stubs = make_pyside6_stub()
+    for name, module in stubs.items():
+        monkeypatch.setitem(sys.modules, name, module)
+
+    def fail(*a, **k):
+        raise AssertionError("Progress dialog shown")
+
+    stubs['PySide6.QtWidgets'].QProgressDialog = fail
+
+    shown = []
+    class DummyApp:
+        def __init__(self, *a, **k):
+            shown.append('app')
+        def exec(self):
+            shown.append('exec')
+    stubs['PySide6.QtWidgets'].QApplication = DummyApp
+
+    class DummyWindow:
+        def show(self):
+            shown.append('show')
+
+    mw = types.ModuleType('main_window')
+    mw.MainWindow = DummyWindow
+    monkeypatch.setitem(sys.modules, 'main_window', mw)
+
+    monkeypatch.setattr(sys, 'argv', ['run_app.py'])
+
+    mod = importlib.import_module('run_app')
+    mod = importlib.reload(mod)
+
+    mod.main()
+
+    assert shown == ['app', 'show', 'exec']
 


### PR DESCRIPTION
## Summary
- start Qt event loop directly without progress dialog
- add unit test verifying progress dialog is not created
- update uninstaller test to support new imports
- document simplified startup in CHANGELOG

## Testing
- `pytest -q`