### PR TITLE
Add PyTorch requirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Whenever a feature is added or removed, update the "Unreleased" section with a d
 - PyInstaller build now loads `pyinstaller_hooks/hook-whispercpp.py` via
   `--additional-hooks-dir` so WhisperCPP's dynamic libraries bundle correctly.
 - Documented Python version requirements in README and user guide; note that newer versions may lack `whispercpp` wheels.
+- `requirements.txt` now lists `torch` and `torchaudio`. README and the user guide instruct users to install these packages when running from source.
 
 ### Changed
  - Replaced `docs/user_guide.pdf` with a plain-text version. The generator

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## 1 — Core Functionality
 
-- The packaged executable embeds Python, a static FFmpeg binary via `static-ffmpeg`, and all required libraries. Install Python and the packages in `requirements.txt` only when running from source.
+- The packaged executable embeds Python, a static FFmpeg binary via `static-ffmpeg`, and all required libraries. Install Python and the packages in `requirements.txt` \(including `torch` and `torchaudio`\) only when running from source.
 - Accept multiple audio files (browse or drag-drop). The file list supports
   drag-and-drop reordering and files are processed in that sequence.
 - Perform local Whisper sentence-level transcription with timestamps and Speaker 1/2/3 tags (users can rename later).
@@ -102,7 +102,7 @@ That’s the entire plan—feature set, tech choices, modules, and deliverables�
 
 ### Prerequisites
 
-- Python 3.10 or 3.11 with all packages from `requirements.txt` (newer versions
+- Python 3.10 or 3.11 with all packages from `requirements.txt` (including `torch` and `torchaudio`; newer versions
   may not have `whispercpp` wheels)
 - `pyinstaller` available on your PATH (`pip install pyinstaller`)
 - (Optional) [NSIS](https://nsis.sourceforge.io/) for creating the final

--- a/build_installer.py
+++ b/build_installer.py
@@ -36,6 +36,8 @@ def main() -> None:
             "--collect-all=whispercpp",
             "--collect-binaries=whispercpp",
             "--hidden-import=whispercpp",
+            "--hidden-import=torch",
+            "--hidden-import=torchaudio",
             f"--add-data={cert_path}{os.pathsep}pip/_vendor/certifi",
             "--distpath",
             out_dir,

--- a/docs/user_guide.txt
+++ b/docs/user_guide.txt
@@ -1,7 +1,7 @@
 Whisper Transcriber User Guide
 
 Installation:
-1. Install Python only if you plan to run from source. FFmpeg is bundled with the application via `static-ffmpeg`.
+1. Install Python and the `torch` and `torchaudio` packages only if you plan to run from source. FFmpeg is bundled with the application via `static-ffmpeg`.
 2. Run 'python build_installer.py' to create the executable.
 3. Launch the installer from 'dist/'. The installed program includes all dependencies.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,6 @@ pyannote.audio
 ffmpeg-python
 PySide6
 static-ffmpeg
+
+torch
+torchaudio


### PR DESCRIPTION
## Summary
- list `torch` and `torchaudio` in `requirements.txt`
- mention that PyTorch and torchaudio must be installed when running from source
- document the new requirement in the changelog
- ensure the installer bundles `torch` and `torchaudio`

## Testing
- `pytest -q`